### PR TITLE
v4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,7 @@
         <url>https://github.com/filip26/copper-multicodec/tree/main</url>
     </scm>
     <properties>
-        <maven.compiler.target>8</maven.compiler.target>
-        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.release>8</maven.compiler.release>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.apicatalog</groupId>
     <artifactId>copper-multicodec</artifactId>
-    <version>3.0.0</version>
+    <version>4.0.0</version>
     <packaging>jar</packaging>
     <url>https://github.com/filip26/copper-multicodec</url>
     <scm>

--- a/src/gen/java/com/apicatalog/multicodec/CodecDef.java
+++ b/src/gen/java/com/apicatalog/multicodec/CodecDef.java
@@ -75,7 +75,6 @@ public class CodecDef {
         return name.replaceAll("-", "_")
                 .replace("priv", "PRIVATE")
                 .replace("pub", "PUBLIC")
-                .toUpperCase()
-                + ((Tag.Key == tag) ? "_KEY" : "");
+                .toUpperCase();
     }
 }

--- a/src/gen/java/com/apicatalog/multicodec/CodecTag.java
+++ b/src/gen/java/com/apicatalog/multicodec/CodecTag.java
@@ -59,7 +59,7 @@ public class CodecTag {
                 writer.println();
             });
 
-            writer.print("    protected static final Map<Long,Multicodec");
+            writer.print("    protected static final Map<Integer,Multicodec");
 //            writer.print(clazz.getSimpleName());
             writer.println("> ALL = new TreeMap<>();");
             writer.println();

--- a/src/main/java/com/apicatalog/multicodec/Multicodec.java
+++ b/src/main/java/com/apicatalog/multicodec/Multicodec.java
@@ -54,7 +54,7 @@ public class Multicodec {
 
     protected final String name;
     protected final byte[] codeVarint;
-    protected final long code;
+    protected final int code;
     protected final Tag tag;
     protected final Status status;
 
@@ -67,7 +67,7 @@ public class Multicodec {
      * @param uvarint the varint-encoded form of the code
      * @param status  the registration status
      */
-    protected Multicodec(String name, Tag tag, long code, byte[] uvarint, Status status) {
+    protected Multicodec(String name, Tag tag, int code, byte[] uvarint, Status status) {
         this.tag = tag;
         this.name = name;
         this.code = code;
@@ -83,7 +83,7 @@ public class Multicodec {
      * @param code the codec numeric code
      * @return a new {@code Multicodec} instance
      */
-    public static Multicodec of(String name, Tag tag, long code) {
+    public static Multicodec of(String name, Tag tag, int code) {
         return of(name, tag, code, null);
     }
 
@@ -96,7 +96,7 @@ public class Multicodec {
      * @param status the codec registration status
      * @return a new {@code Multicodec} instance
      */
-    public static Multicodec of(String name, Tag tag, long code, Status status) {
+    public static Multicodec of(String name, Tag tag, int code, Status status) {
         return new Multicodec(name, tag, code, UVarInt.encode(code), status);
     }
 
@@ -334,7 +334,7 @@ public class Multicodec {
      * 
      * @return the numeric code
      */
-    public long code() {
+    public int code() {
         return code;
     }
 

--- a/src/main/java/com/apicatalog/multicodec/MulticodecDecoder.java
+++ b/src/main/java/com/apicatalog/multicodec/MulticodecDecoder.java
@@ -39,7 +39,7 @@ public class MulticodecDecoder {
      * 
      * @return a new decoder instance containing all known codecs
      */
-    public static MulticodecDecoder getInstance() {
+    public static MulticodecDecoder newInstance() {
         return new MulticodecDecoder(MulticodecRegistry.getInstance());
     }
 
@@ -54,7 +54,7 @@ public class MulticodecDecoder {
      * @param tags one or more codec tags to match
      * @return a new decoder instance containing only codecs with matching tags
      */
-    public static MulticodecDecoder getInstance(Tag... tags) {
+    public static MulticodecDecoder newInstance(Tag... tags) {
         Objects.requireNonNull(tags);
 
         if (tags.length == 0) {
@@ -71,7 +71,7 @@ public class MulticodecDecoder {
      * @param codecs one or more codecs to register
      * @return a new decoder instance containing only the provided codecs
      */
-    public static MulticodecDecoder getInstance(Multicodec... codecs) {
+    public static MulticodecDecoder newInstance(Multicodec... codecs) {
         Objects.requireNonNull(codecs);
 
         if (codecs.length == 0) {
@@ -97,10 +97,19 @@ public class MulticodecDecoder {
         if (encoded.length == 0) {
             throw new IllegalArgumentException("The encoded value must be a non-empty byte array.");
         }
-
+        
         final long code = UVarInt.decode(encoded);
+        if (code < Integer.MIN_VALUE || code > Integer.MAX_VALUE) {
+            
+            StringBuilder hex = new StringBuilder();
+            for (byte b : encoded) {
+                hex.append(String.format("%02x", b));
+            }
+            
+            throw new IllegalArgumentException("The code is out of range, code=" + Long.toUnsignedString(code) + ", varint=" + hex.toString());
+        }
 
-        return registry.getCodec(code);
+        return registry.getCodec((int) code);
     }
 
     /**

--- a/src/main/java/com/apicatalog/multicodec/codec/CidCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/CidCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 23:11:10 CEST 2026 */
 public class CidCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.004Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T21:11:10.639296152Z");
 
     /** Cid: cidv1, CIDv1, status = permanent, code = 0x1 */
     public static final Multicodec CIDV1 = Multicodec.of("cidv1", Tag.Cid, 0x1, Multicodec.Status.Permanent);

--- a/src/main/java/com/apicatalog/multicodec/codec/CidCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/CidCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jun 01 18:59:15 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
 public class CidCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-06-01T16:59:15.577Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.004Z");
 
     /** Cid: cidv1, CIDv1, status = permanent, code = 0x1 */
     public static final Multicodec CIDV1 = Multicodec.of("cidv1", Tag.Cid, 0x1, Multicodec.Status.Permanent);
@@ -21,7 +21,7 @@ public class CidCodec {
     /** Cid: cidv3, CIDv3, status = draft, code = 0x3 */
     public static final Multicodec CIDV3 = Multicodec.of("cidv3", Tag.Cid, 0x3, Multicodec.Status.Draft);
 
-    protected static final Map<Long,Multicodec> ALL = new TreeMap<>();
+    protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
       ALL.put(CIDV1.code(), CIDV1);

--- a/src/main/java/com/apicatalog/multicodec/codec/HashCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/HashCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 23:11:10 CEST 2026 */
 public class HashCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T21:11:10.636258289Z");
 
     /** Hash: crc32, CRC-32 non-cryptographic hash algorithm (IEEE 802.3), status = draft, code = 0x132 */
     public static final Multicodec CRC32 = Multicodec.of("crc32", Tag.Hash, 0x132, Multicodec.Status.Draft);

--- a/src/main/java/com/apicatalog/multicodec/codec/HashCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/HashCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jun 01 18:59:15 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
 public class HashCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-06-01T16:59:15.575Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56Z");
 
     /** Hash: crc32, CRC-32 non-cryptographic hash algorithm (IEEE 802.3), status = draft, code = 0x132 */
     public static final Multicodec CRC32 = Multicodec.of("crc32", Tag.Hash, 0x132, Multicodec.Status.Draft);
@@ -45,7 +45,7 @@ public class HashCodec {
     /** Hash: xxh3-64, Extremely fast non-cryptographic hash algorithm, status = draft, code = 0xb3e3 */
     public static final Multicodec XXH3_64 = Multicodec.of("xxh3-64", Tag.Hash, 0xb3e3, Multicodec.Status.Draft);
 
-    protected static final Map<Long,Multicodec> ALL = new TreeMap<>();
+    protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
       ALL.put(CRC32.code(), CRC32);

--- a/src/main/java/com/apicatalog/multicodec/codec/KeyCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/KeyCodec.java
@@ -7,370 +7,372 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jul 06 22:44:55 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 23:11:10 CEST 2026 */
 public class KeyCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:55.886Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T21:11:10.562607319Z");
 
     /** Key: aes-128, 128-bit AES symmetric key, status = draft, code = 0xa0 */
-    public static final Multicodec AES_128_KEY = Multicodec.of("aes-128", Tag.Key, 0xa0, Multicodec.Status.Draft);
+    public static final Multicodec AES_128 = Multicodec.of("aes-128", Tag.Key, 0xa0, Multicodec.Status.Draft);
 
     /** Key: aes-192, 192-bit AES symmetric key, status = draft, code = 0xa1 */
-    public static final Multicodec AES_192_KEY = Multicodec.of("aes-192", Tag.Key, 0xa1, Multicodec.Status.Draft);
+    public static final Multicodec AES_192 = Multicodec.of("aes-192", Tag.Key, 0xa1, Multicodec.Status.Draft);
 
     /** Key: aes-256, 256-bit AES symmetric key, status = draft, code = 0xa2 */
-    public static final Multicodec AES_256_KEY = Multicodec.of("aes-256", Tag.Key, 0xa2, Multicodec.Status.Draft);
+    public static final Multicodec AES_256 = Multicodec.of("aes-256", Tag.Key, 0xa2, Multicodec.Status.Draft);
 
     /** Key: bip340-priv, BIP340 private key, status = draft, code = 0x1341 */
-    public static final Multicodec BIP340_PRIVATE_KEY = Multicodec.of("bip340-priv", Tag.Key, 0x1341, Multicodec.Status.Draft);
+    public static final Multicodec BIP340_PRIVATE = Multicodec.of("bip340-priv", Tag.Key, 0x1341, Multicodec.Status.Draft);
 
     /** Key: bip340-pub, BIP340 public key, status = draft, code = 0x1340 */
-    public static final Multicodec BIP340_PUBLIC_KEY = Multicodec.of("bip340-pub", Tag.Key, 0x1340, Multicodec.Status.Draft);
+    public static final Multicodec BIP340_PUBLIC = Multicodec.of("bip340-pub", Tag.Key, 0x1340, Multicodec.Status.Draft);
 
     /** Key: bls12_381-g1-priv, BLS12-381 G1 private key, status = draft, code = 0x1309 */
-    public static final Multicodec BLS12_381_G1_PRIVATE_KEY = Multicodec.of("bls12_381-g1-priv", Tag.Key, 0x1309, Multicodec.Status.Draft);
+    public static final Multicodec BLS12_381_G1_PRIVATE = Multicodec.of("bls12_381-g1-priv", Tag.Key, 0x1309, Multicodec.Status.Draft);
 
     /** Key: bls12_381-g1-priv-share, BLS12-381 G1 private key share, status = draft, code = 0x130e */
-    public static final Multicodec BLS12_381_G1_PRIVATE_SHARE_KEY = Multicodec.of("bls12_381-g1-priv-share", Tag.Key, 0x130e, Multicodec.Status.Draft);
+    public static final Multicodec BLS12_381_G1_PRIVATE_SHARE = Multicodec.of("bls12_381-g1-priv-share", Tag.Key, 0x130e, Multicodec.Status.Draft);
 
     /** Key: bls12_381-g1-pub, BLS12-381 public key in the G1 field, status = draft, code = 0xea */
-    public static final Multicodec BLS12_381_G1_PUBLIC_KEY = Multicodec.of("bls12_381-g1-pub", Tag.Key, 0xea, Multicodec.Status.Draft);
+    public static final Multicodec BLS12_381_G1_PUBLIC = Multicodec.of("bls12_381-g1-pub", Tag.Key, 0xea, Multicodec.Status.Draft);
 
     /** Key: bls12_381-g1-pub-share, BLS12-381 G1 public key share, status = draft, code = 0x130c */
-    public static final Multicodec BLS12_381_G1_PUBLIC_SHARE_KEY = Multicodec.of("bls12_381-g1-pub-share", Tag.Key, 0x130c, Multicodec.Status.Draft);
+    public static final Multicodec BLS12_381_G1_PUBLIC_SHARE = Multicodec.of("bls12_381-g1-pub-share", Tag.Key, 0x130c, Multicodec.Status.Draft);
 
     /** Key: bls12_381-g1g2-priv, BLS12-381 G1 and G2 private key, status = draft, code = 0x130b */
-    public static final Multicodec BLS12_381_G1G2_PRIVATE_KEY = Multicodec.of("bls12_381-g1g2-priv", Tag.Key, 0x130b, Multicodec.Status.Draft);
+    public static final Multicodec BLS12_381_G1G2_PRIVATE = Multicodec.of("bls12_381-g1g2-priv", Tag.Key, 0x130b, Multicodec.Status.Draft);
 
     /** Key: bls12_381-g1g2-pub, BLS12-381 concatenated public keys in both the G1 and G2 fields, status = draft, code = 0xee */
-    public static final Multicodec BLS12_381_G1G2_PUBLIC_KEY = Multicodec.of("bls12_381-g1g2-pub", Tag.Key, 0xee, Multicodec.Status.Draft);
+    public static final Multicodec BLS12_381_G1G2_PUBLIC = Multicodec.of("bls12_381-g1g2-pub", Tag.Key, 0xee, Multicodec.Status.Draft);
 
     /** Key: bls12_381-g2-priv, BLS12-381 G2 private key, status = draft, code = 0x130a */
-    public static final Multicodec BLS12_381_G2_PRIVATE_KEY = Multicodec.of("bls12_381-g2-priv", Tag.Key, 0x130a, Multicodec.Status.Draft);
+    public static final Multicodec BLS12_381_G2_PRIVATE = Multicodec.of("bls12_381-g2-priv", Tag.Key, 0x130a, Multicodec.Status.Draft);
 
     /** Key: bls12_381-g2-priv-share, BLS12-381 G2 private key share, status = draft, code = 0x130f */
-    public static final Multicodec BLS12_381_G2_PRIVATE_SHARE_KEY = Multicodec.of("bls12_381-g2-priv-share", Tag.Key, 0x130f, Multicodec.Status.Draft);
+    public static final Multicodec BLS12_381_G2_PRIVATE_SHARE = Multicodec.of("bls12_381-g2-priv-share", Tag.Key, 0x130f, Multicodec.Status.Draft);
 
     /** Key: bls12_381-g2-pub, BLS12-381 public key in the G2 field, status = draft, code = 0xeb */
-    public static final Multicodec BLS12_381_G2_PUBLIC_KEY = Multicodec.of("bls12_381-g2-pub", Tag.Key, 0xeb, Multicodec.Status.Draft);
+    public static final Multicodec BLS12_381_G2_PUBLIC = Multicodec.of("bls12_381-g2-pub", Tag.Key, 0xeb, Multicodec.Status.Draft);
 
     /** Key: bls12_381-g2-pub-share, BLS12-381 G2 public key share, status = draft, code = 0x130d */
-    public static final Multicodec BLS12_381_G2_PUBLIC_SHARE_KEY = Multicodec.of("bls12_381-g2-pub-share", Tag.Key, 0x130d, Multicodec.Status.Draft);
+    public static final Multicodec BLS12_381_G2_PUBLIC_SHARE = Multicodec.of("bls12_381-g2-pub-share", Tag.Key, 0x130d, Multicodec.Status.Draft);
 
     /** Key: chacha-128, 128-bit ChaCha symmetric key, status = draft, code = 0xa3 */
-    public static final Multicodec CHACHA_128_KEY = Multicodec.of("chacha-128", Tag.Key, 0xa3, Multicodec.Status.Draft);
+    public static final Multicodec CHACHA_128 = Multicodec.of("chacha-128", Tag.Key, 0xa3, Multicodec.Status.Draft);
 
     /** Key: chacha-256, 256-bit ChaCha symmetric key, status = draft, code = 0xa4 */
-    public static final Multicodec CHACHA_256_KEY = Multicodec.of("chacha-256", Tag.Key, 0xa4, Multicodec.Status.Draft);
+    public static final Multicodec CHACHA_256 = Multicodec.of("chacha-256", Tag.Key, 0xa4, Multicodec.Status.Draft);
 
     /** Key: ed25519-priv, Ed25519 private key, status = draft, code = 0x1300 */
-    public static final Multicodec ED25519_PRIVATE_KEY = Multicodec.of("ed25519-priv", Tag.Key, 0x1300, Multicodec.Status.Draft);
+    public static final Multicodec ED25519_PRIVATE = Multicodec.of("ed25519-priv", Tag.Key, 0x1300, Multicodec.Status.Draft);
 
     /** Key: ed25519-pub, Ed25519 public key, status = draft, code = 0xed */
-    public static final Multicodec ED25519_PUBLIC_KEY = Multicodec.of("ed25519-pub", Tag.Key, 0xed, Multicodec.Status.Draft);
+    public static final Multicodec ED25519_PUBLIC = Multicodec.of("ed25519-pub", Tag.Key, 0xed, Multicodec.Status.Draft);
 
     /** Key: ed448-priv, Ed448 private key, status = draft, code = 0x1311 */
-    public static final Multicodec ED448_PRIVATE_KEY = Multicodec.of("ed448-priv", Tag.Key, 0x1311, Multicodec.Status.Draft);
+    public static final Multicodec ED448_PRIVATE = Multicodec.of("ed448-priv", Tag.Key, 0x1311, Multicodec.Status.Draft);
 
     /** Key: ed448-pub, Ed448 public key, status = draft, code = 0x1203 */
-    public static final Multicodec ED448_PUBLIC_KEY = Multicodec.of("ed448-pub", Tag.Key, 0x1203, Multicodec.Status.Draft);
+    public static final Multicodec ED448_PUBLIC = Multicodec.of("ed448-pub", Tag.Key, 0x1203, Multicodec.Status.Draft);
 
     /** Key: jwk_jcs-priv, JSON object containing only the required members of a JWK (RFC 7518 and RFC 7517) representing the private key. Serialisation based on JCS (RFC 8785), status = draft, code = 0x1316 */
-    public static final Multicodec JWK_JCS_PRIVATE_KEY = Multicodec.of("jwk_jcs-priv", Tag.Key, 0x1316, Multicodec.Status.Draft);
+    public static final Multicodec JWK_JCS_PRIVATE = Multicodec.of("jwk_jcs-priv", Tag.Key, 0x1316, Multicodec.Status.Draft);
 
     /** Key: jwk_jcs-pub, JSON object containing only the required members of a JWK (RFC 7518 and RFC 7517) representing the public key. Serialisation based on JCS (RFC 8785), status = draft, code = 0xeb51 */
-    public static final Multicodec JWK_JCS_PUBLIC_KEY = Multicodec.of("jwk_jcs-pub", Tag.Key, 0xeb51, Multicodec.Status.Draft);
+    public static final Multicodec JWK_JCS_PUBLIC = Multicodec.of("jwk_jcs-pub", Tag.Key, 0xeb51, Multicodec.Status.Draft);
 
     /** Key: lamport-sha3-256-priv, Lamport private key based on SHA3-256, status = draft, code = 0x1a26 */
-    public static final Multicodec LAMPORT_SHA3_256_PRIVATE_KEY = Multicodec.of("lamport-sha3-256-priv", Tag.Key, 0x1a26, Multicodec.Status.Draft);
+    public static final Multicodec LAMPORT_SHA3_256_PRIVATE = Multicodec.of("lamport-sha3-256-priv", Tag.Key, 0x1a26, Multicodec.Status.Draft);
 
     /** Key: lamport-sha3-256-priv-share, Lamport private key share based on SHA3-256 and split with Shamir gf256, status = draft, code = 0x1a36 */
-    public static final Multicodec LAMPORT_SHA3_256_PRIVATE_SHARE_KEY = Multicodec.of("lamport-sha3-256-priv-share", Tag.Key, 0x1a36, Multicodec.Status.Draft);
+    public static final Multicodec LAMPORT_SHA3_256_PRIVATE_SHARE = Multicodec.of("lamport-sha3-256-priv-share", Tag.Key, 0x1a36, Multicodec.Status.Draft);
 
     /** Key: lamport-sha3-256-pub, Lamport public key based on SHA3-256, status = draft, code = 0x1a16 */
-    public static final Multicodec LAMPORT_SHA3_256_PUBLIC_KEY = Multicodec.of("lamport-sha3-256-pub", Tag.Key, 0x1a16, Multicodec.Status.Draft);
+    public static final Multicodec LAMPORT_SHA3_256_PUBLIC = Multicodec.of("lamport-sha3-256-pub", Tag.Key, 0x1a16, Multicodec.Status.Draft);
 
     /** Key: lamport-sha3-384-priv, Lamport private key based on SHA3-384, status = draft, code = 0x1a25 */
-    public static final Multicodec LAMPORT_SHA3_384_PRIVATE_KEY = Multicodec.of("lamport-sha3-384-priv", Tag.Key, 0x1a25, Multicodec.Status.Draft);
+    public static final Multicodec LAMPORT_SHA3_384_PRIVATE = Multicodec.of("lamport-sha3-384-priv", Tag.Key, 0x1a25, Multicodec.Status.Draft);
 
     /** Key: lamport-sha3-384-priv-share, Lamport private key share based on SHA3-384 and split with Shamir gf256, status = draft, code = 0x1a35 */
-    public static final Multicodec LAMPORT_SHA3_384_PRIVATE_SHARE_KEY = Multicodec.of("lamport-sha3-384-priv-share", Tag.Key, 0x1a35, Multicodec.Status.Draft);
+    public static final Multicodec LAMPORT_SHA3_384_PRIVATE_SHARE = Multicodec.of("lamport-sha3-384-priv-share", Tag.Key, 0x1a35, Multicodec.Status.Draft);
 
     /** Key: lamport-sha3-384-pub, Lamport public key based on SHA3-384, status = draft, code = 0x1a15 */
-    public static final Multicodec LAMPORT_SHA3_384_PUBLIC_KEY = Multicodec.of("lamport-sha3-384-pub", Tag.Key, 0x1a15, Multicodec.Status.Draft);
+    public static final Multicodec LAMPORT_SHA3_384_PUBLIC = Multicodec.of("lamport-sha3-384-pub", Tag.Key, 0x1a15, Multicodec.Status.Draft);
 
     /** Key: lamport-sha3-512-priv, Lamport private key based on SHA3-512, status = draft, code = 0x1a24 */
-    public static final Multicodec LAMPORT_SHA3_512_PRIVATE_KEY = Multicodec.of("lamport-sha3-512-priv", Tag.Key, 0x1a24, Multicodec.Status.Draft);
+    public static final Multicodec LAMPORT_SHA3_512_PRIVATE = Multicodec.of("lamport-sha3-512-priv", Tag.Key, 0x1a24, Multicodec.Status.Draft);
 
     /** Key: lamport-sha3-512-priv-share, Lamport private key share based on SHA3-512 and split with Shamir gf256, status = draft, code = 0x1a34 */
-    public static final Multicodec LAMPORT_SHA3_512_PRIVATE_SHARE_KEY = Multicodec.of("lamport-sha3-512-priv-share", Tag.Key, 0x1a34, Multicodec.Status.Draft);
+    public static final Multicodec LAMPORT_SHA3_512_PRIVATE_SHARE = Multicodec.of("lamport-sha3-512-priv-share", Tag.Key, 0x1a34, Multicodec.Status.Draft);
 
     /** Key: lamport-sha3-512-pub, Lamport public key based on SHA3-512, status = draft, code = 0x1a14 */
-    public static final Multicodec LAMPORT_SHA3_512_PUBLIC_KEY = Multicodec.of("lamport-sha3-512-pub", Tag.Key, 0x1a14, Multicodec.Status.Draft);
+    public static final Multicodec LAMPORT_SHA3_512_PUBLIC = Multicodec.of("lamport-sha3-512-pub", Tag.Key, 0x1a14, Multicodec.Status.Draft);
 
     /** Key: mldsa-44-priv, ML-DSA 44 private key; expanded key format (2560 bytes) as specified by FIPS 204, status = draft, code = 0x1317 */
-    public static final Multicodec MLDSA_44_PRIVATE_KEY = Multicodec.of("mldsa-44-priv", Tag.Key, 0x1317, Multicodec.Status.Draft);
+    public static final Multicodec MLDSA_44_PRIVATE = Multicodec.of("mldsa-44-priv", Tag.Key, 0x1317, Multicodec.Status.Draft);
 
     /** Key: mldsa-44-priv-seed, ML-DSA 44 private key seed; (32 bytes) as specified by FIPS 204, status = draft, code = 0x131a */
-    public static final Multicodec MLDSA_44_PRIVATE_SEED_KEY = Multicodec.of("mldsa-44-priv-seed", Tag.Key, 0x131a, Multicodec.Status.Draft);
+    public static final Multicodec MLDSA_44_PRIVATE_SEED = Multicodec.of("mldsa-44-priv-seed", Tag.Key, 0x131a, Multicodec.Status.Draft);
 
     /** Key: mldsa-44-pub, ML-DSA 44 public key; as specified by FIPS 204, status = draft, code = 0x1210 */
-    public static final Multicodec MLDSA_44_PUBLIC_KEY = Multicodec.of("mldsa-44-pub", Tag.Key, 0x1210, Multicodec.Status.Draft);
+    public static final Multicodec MLDSA_44_PUBLIC = Multicodec.of("mldsa-44-pub", Tag.Key, 0x1210, Multicodec.Status.Draft);
 
     /** Key: mldsa-65-priv, ML-DSA 65 private key; expanded key format (4032 bytes) as specified by FIPS 204, status = draft, code = 0x1318 */
-    public static final Multicodec MLDSA_65_PRIVATE_KEY = Multicodec.of("mldsa-65-priv", Tag.Key, 0x1318, Multicodec.Status.Draft);
+    public static final Multicodec MLDSA_65_PRIVATE = Multicodec.of("mldsa-65-priv", Tag.Key, 0x1318, Multicodec.Status.Draft);
 
     /** Key: mldsa-65-priv-seed, ML-DSA 65 private key seed; (32 bytes) as specified by FIPS 204, status = draft, code = 0x131b */
-    public static final Multicodec MLDSA_65_PRIVATE_SEED_KEY = Multicodec.of("mldsa-65-priv-seed", Tag.Key, 0x131b, Multicodec.Status.Draft);
+    public static final Multicodec MLDSA_65_PRIVATE_SEED = Multicodec.of("mldsa-65-priv-seed", Tag.Key, 0x131b, Multicodec.Status.Draft);
 
     /** Key: mldsa-65-pub, ML-DSA 65 public key; as specified by FIPS 204, status = draft, code = 0x1211 */
-    public static final Multicodec MLDSA_65_PUBLIC_KEY = Multicodec.of("mldsa-65-pub", Tag.Key, 0x1211, Multicodec.Status.Draft);
+    public static final Multicodec MLDSA_65_PUBLIC = Multicodec.of("mldsa-65-pub", Tag.Key, 0x1211, Multicodec.Status.Draft);
 
     /** Key: mldsa-87-priv, ML-DSA 87 private key; expanded key format (4896 bytes) as specified by FIPS 204, status = draft, code = 0x1319 */
-    public static final Multicodec MLDSA_87_PRIVATE_KEY = Multicodec.of("mldsa-87-priv", Tag.Key, 0x1319, Multicodec.Status.Draft);
+    public static final Multicodec MLDSA_87_PRIVATE = Multicodec.of("mldsa-87-priv", Tag.Key, 0x1319, Multicodec.Status.Draft);
 
     /** Key: mldsa-87-priv-seed, ML-DSA 87 private key seed; (32 bytes) as specified by FIPS 204, status = draft, code = 0x131c */
-    public static final Multicodec MLDSA_87_PRIVATE_SEED_KEY = Multicodec.of("mldsa-87-priv-seed", Tag.Key, 0x131c, Multicodec.Status.Draft);
+    public static final Multicodec MLDSA_87_PRIVATE_SEED = Multicodec.of("mldsa-87-priv-seed", Tag.Key, 0x131c, Multicodec.Status.Draft);
 
     /** Key: mldsa-87-pub, ML-DSA 87 public key; as specified by FIPS 204, status = draft, code = 0x1212 */
-    public static final Multicodec MLDSA_87_PUBLIC_KEY = Multicodec.of("mldsa-87-pub", Tag.Key, 0x1212, Multicodec.Status.Draft);
+    public static final Multicodec MLDSA_87_PUBLIC = Multicodec.of("mldsa-87-pub", Tag.Key, 0x1212, Multicodec.Status.Draft);
 
     /** Key: mlkem-1024-priv, ML-KEM 1024 private key; as specified by FIPS 203, status = draft, code = 0x1315 */
-    public static final Multicodec MLKEM_1024_PRIVATE_KEY = Multicodec.of("mlkem-1024-priv", Tag.Key, 0x1315, Multicodec.Status.Draft);
+    public static final Multicodec MLKEM_1024_PRIVATE = Multicodec.of("mlkem-1024-priv", Tag.Key, 0x1315, Multicodec.Status.Draft);
 
     /** Key: mlkem-1024-pub, ML-KEM 1024 public key; as specified by FIPS 203, status = draft, code = 0x120d */
-    public static final Multicodec MLKEM_1024_PUBLIC_KEY = Multicodec.of("mlkem-1024-pub", Tag.Key, 0x120d, Multicodec.Status.Draft);
+    public static final Multicodec MLKEM_1024_PUBLIC = Multicodec.of("mlkem-1024-pub", Tag.Key, 0x120d, Multicodec.Status.Draft);
 
     /** Key: mlkem-512-priv, ML-KEM 512 private key; as specified by FIPS 203, status = draft, code = 0x1313 */
-    public static final Multicodec MLKEM_512_PRIVATE_KEY = Multicodec.of("mlkem-512-priv", Tag.Key, 0x1313, Multicodec.Status.Draft);
+    public static final Multicodec MLKEM_512_PRIVATE = Multicodec.of("mlkem-512-priv", Tag.Key, 0x1313, Multicodec.Status.Draft);
 
     /** Key: mlkem-512-pub, ML-KEM 512 public key; as specified by FIPS 203, status = draft, code = 0x120b */
-    public static final Multicodec MLKEM_512_PUBLIC_KEY = Multicodec.of("mlkem-512-pub", Tag.Key, 0x120b, Multicodec.Status.Draft);
+    public static final Multicodec MLKEM_512_PUBLIC = Multicodec.of("mlkem-512-pub", Tag.Key, 0x120b, Multicodec.Status.Draft);
 
     /** Key: mlkem-768-priv, ML-KEM 768 private key; as specified by FIPS 203, status = draft, code = 0x1314 */
-    public static final Multicodec MLKEM_768_PRIVATE_KEY = Multicodec.of("mlkem-768-priv", Tag.Key, 0x1314, Multicodec.Status.Draft);
+    public static final Multicodec MLKEM_768_PRIVATE = Multicodec.of("mlkem-768-priv", Tag.Key, 0x1314, Multicodec.Status.Draft);
 
     /** Key: mlkem-768-pub, ML-KEM 768 public key; as specified by FIPS 203, status = draft, code = 0x120c */
-    public static final Multicodec MLKEM_768_PUBLIC_KEY = Multicodec.of("mlkem-768-pub", Tag.Key, 0x120c, Multicodec.Status.Draft);
+    public static final Multicodec MLKEM_768_PUBLIC = Multicodec.of("mlkem-768-pub", Tag.Key, 0x120c, Multicodec.Status.Draft);
 
     /** Key: p256-priv, P-256 private key, status = draft, code = 0x1306 */
-    public static final Multicodec P256_PRIVATE_KEY = Multicodec.of("p256-priv", Tag.Key, 0x1306, Multicodec.Status.Draft);
+    public static final Multicodec P256_PRIVATE = Multicodec.of("p256-priv", Tag.Key, 0x1306, Multicodec.Status.Draft);
 
     /** Key: p256-pub, P-256 public key (compressed), status = draft, code = 0x1200 */
-    public static final Multicodec P256_PUBLIC_KEY = Multicodec.of("p256-pub", Tag.Key, 0x1200, Multicodec.Status.Draft);
+    public static final Multicodec P256_PUBLIC = Multicodec.of("p256-pub", Tag.Key, 0x1200, Multicodec.Status.Draft);
 
     /** Key: p384-priv, P-384 private key, status = draft, code = 0x1307 */
-    public static final Multicodec P384_PRIVATE_KEY = Multicodec.of("p384-priv", Tag.Key, 0x1307, Multicodec.Status.Draft);
+    public static final Multicodec P384_PRIVATE = Multicodec.of("p384-priv", Tag.Key, 0x1307, Multicodec.Status.Draft);
 
     /** Key: p384-pub, P-384 public key (compressed), status = draft, code = 0x1201 */
-    public static final Multicodec P384_PUBLIC_KEY = Multicodec.of("p384-pub", Tag.Key, 0x1201, Multicodec.Status.Draft);
+    public static final Multicodec P384_PUBLIC = Multicodec.of("p384-pub", Tag.Key, 0x1201, Multicodec.Status.Draft);
 
     /** Key: p521-priv, P-521 private key, status = draft, code = 0x1308 */
-    public static final Multicodec P521_PRIVATE_KEY = Multicodec.of("p521-priv", Tag.Key, 0x1308, Multicodec.Status.Draft);
+    public static final Multicodec P521_PRIVATE = Multicodec.of("p521-priv", Tag.Key, 0x1308, Multicodec.Status.Draft);
 
     /** Key: p521-pub, P-521 public key (compressed), status = draft, code = 0x1202 */
-    public static final Multicodec P521_PUBLIC_KEY = Multicodec.of("p521-pub", Tag.Key, 0x1202, Multicodec.Status.Draft);
+    public static final Multicodec P521_PUBLIC = Multicodec.of("p521-pub", Tag.Key, 0x1202, Multicodec.Status.Draft);
 
     /** Key: rsa-priv, RSA private key, status = draft, code = 0x1305 */
-    public static final Multicodec RSA_PRIVATE_KEY = Multicodec.of("rsa-priv", Tag.Key, 0x1305, Multicodec.Status.Draft);
+    public static final Multicodec RSA_PRIVATE = Multicodec.of("rsa-priv", Tag.Key, 0x1305, Multicodec.Status.Draft);
 
     /** Key: rsa-pub, RSA public key. DER-encoded ASN.1 type RSAPublicKey according to IETF RFC 8017 (PKCS #1), status = draft, code = 0x1205 */
-    public static final Multicodec RSA_PUBLIC_KEY = Multicodec.of("rsa-pub", Tag.Key, 0x1205, Multicodec.Status.Draft);
+    public static final Multicodec RSA_PUBLIC = Multicodec.of("rsa-pub", Tag.Key, 0x1205, Multicodec.Status.Draft);
 
     /** Key: secp256k1-priv, Secp256k1 private key, status = draft, code = 0x1301 */
-    public static final Multicodec SECP256K1_PRIVATE_KEY = Multicodec.of("secp256k1-priv", Tag.Key, 0x1301, Multicodec.Status.Draft);
+    public static final Multicodec SECP256K1_PRIVATE = Multicodec.of("secp256k1-priv", Tag.Key, 0x1301, Multicodec.Status.Draft);
 
     /** Key: secp256k1-pub, Secp256k1 public key (compressed), status = draft, code = 0xe7 */
-    public static final Multicodec SECP256K1_PUBLIC_KEY = Multicodec.of("secp256k1-pub", Tag.Key, 0xe7, Multicodec.Status.Draft);
+    public static final Multicodec SECP256K1_PUBLIC = Multicodec.of("secp256k1-pub", Tag.Key, 0xe7, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-128f-priv, SLH-DSA-SHA2-128f private key; as specified by FIPS 205, status = draft, code = 0x131f */
-    public static final Multicodec SLHDSA_SHA2_128F_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-128f-priv", Tag.Key, 0x131f, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_128F_PRIVATE = Multicodec.of("slhdsa-sha2-128f-priv", Tag.Key, 0x131f, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-128f-pub, SLH-DSA-SHA2-128f public key; as specified by FIPS 205, status = draft, code = 0x1222 */
-    public static final Multicodec SLHDSA_SHA2_128F_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-128f-pub", Tag.Key, 0x1222, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_128F_PUBLIC = Multicodec.of("slhdsa-sha2-128f-pub", Tag.Key, 0x1222, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-128s-priv, SLH-DSA-SHA2-128s private key; as specified by FIPS 205, status = draft, code = 0x131d */
-    public static final Multicodec SLHDSA_SHA2_128S_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-128s-priv", Tag.Key, 0x131d, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_128S_PRIVATE = Multicodec.of("slhdsa-sha2-128s-priv", Tag.Key, 0x131d, Multicodec.Status.Draft);
 
+    public static final int SLHDSA_SHA2_128S_PRIVATE_CODE = 0x131d;
+    
     /** Key: slhdsa-sha2-128s-pub, SLH-DSA-SHA2-128s public key; as specified by FIPS 205, status = draft, code = 0x1220 */
-    public static final Multicodec SLHDSA_SHA2_128S_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-128s-pub", Tag.Key, 0x1220, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_128S_PUBLIC = Multicodec.of("slhdsa-sha2-128s-pub", Tag.Key, 0x1220, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-192f-priv, SLH-DSA-SHA2-192f private key; as specified by FIPS 205, status = draft, code = 0x1323 */
-    public static final Multicodec SLHDSA_SHA2_192F_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-192f-priv", Tag.Key, 0x1323, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_192F_PRIVATE = Multicodec.of("slhdsa-sha2-192f-priv", Tag.Key, 0x1323, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-192f-pub, SLH-DSA-SHA2-192f public key; as specified by FIPS 205, status = draft, code = 0x1226 */
-    public static final Multicodec SLHDSA_SHA2_192F_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-192f-pub", Tag.Key, 0x1226, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_192F_PUBLIC = Multicodec.of("slhdsa-sha2-192f-pub", Tag.Key, 0x1226, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-192s-priv, SLH-DSA-SHA2-192s private key; as specified by FIPS 205, status = draft, code = 0x1321 */
-    public static final Multicodec SLHDSA_SHA2_192S_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-192s-priv", Tag.Key, 0x1321, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_192S_PRIVATE = Multicodec.of("slhdsa-sha2-192s-priv", Tag.Key, 0x1321, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-192s-pub, SLH-DSA-SHA2-192s public key; as specified by FIPS 205, status = draft, code = 0x1224 */
-    public static final Multicodec SLHDSA_SHA2_192S_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-192s-pub", Tag.Key, 0x1224, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_192S_PUBLIC = Multicodec.of("slhdsa-sha2-192s-pub", Tag.Key, 0x1224, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-256f-priv, SLH-DSA-SHA2-256f private key; as specified by FIPS 205, status = draft, code = 0x1327 */
-    public static final Multicodec SLHDSA_SHA2_256F_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-256f-priv", Tag.Key, 0x1327, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_256F_PRIVATE = Multicodec.of("slhdsa-sha2-256f-priv", Tag.Key, 0x1327, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-256f-pub, SLH-DSA-SHA2-256f public key; as specified by FIPS 205, status = draft, code = 0x122a */
-    public static final Multicodec SLHDSA_SHA2_256F_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-256f-pub", Tag.Key, 0x122a, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_256F_PUBLIC = Multicodec.of("slhdsa-sha2-256f-pub", Tag.Key, 0x122a, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-256s-priv, SLH-DSA-SHA2-256s private key; as specified by FIPS 205, status = draft, code = 0x1325 */
-    public static final Multicodec SLHDSA_SHA2_256S_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-256s-priv", Tag.Key, 0x1325, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_256S_PRIVATE = Multicodec.of("slhdsa-sha2-256s-priv", Tag.Key, 0x1325, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-256s-pub, SLH-DSA-SHA2-256s public key; as specified by FIPS 205, status = draft, code = 0x1228 */
-    public static final Multicodec SLHDSA_SHA2_256S_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-256s-pub", Tag.Key, 0x1228, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHA2_256S_PUBLIC = Multicodec.of("slhdsa-sha2-256s-pub", Tag.Key, 0x1228, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-128f-priv, SLH-DSA-SHAKE-128f private key; as specified by FIPS 205, status = draft, code = 0x1320 */
-    public static final Multicodec SLHDSA_SHAKE_128F_PRIVATE_KEY = Multicodec.of("slhdsa-shake-128f-priv", Tag.Key, 0x1320, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_128F_PRIVATE = Multicodec.of("slhdsa-shake-128f-priv", Tag.Key, 0x1320, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-128f-pub, SLH-DSA-SHAKE-128f public key; as specified by FIPS 205, status = draft, code = 0x1223 */
-    public static final Multicodec SLHDSA_SHAKE_128F_PUBLIC_KEY = Multicodec.of("slhdsa-shake-128f-pub", Tag.Key, 0x1223, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_128F_PUBLIC = Multicodec.of("slhdsa-shake-128f-pub", Tag.Key, 0x1223, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-128s-priv, SLH-DSA-SHAKE-128s private key; as specified by FIPS 205, status = draft, code = 0x131e */
-    public static final Multicodec SLHDSA_SHAKE_128S_PRIVATE_KEY = Multicodec.of("slhdsa-shake-128s-priv", Tag.Key, 0x131e, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_128S_PRIVATE = Multicodec.of("slhdsa-shake-128s-priv", Tag.Key, 0x131e, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-128s-pub, SLH-DSA-SHAKE-128s public key; as specified by FIPS 205, status = draft, code = 0x1221 */
-    public static final Multicodec SLHDSA_SHAKE_128S_PUBLIC_KEY = Multicodec.of("slhdsa-shake-128s-pub", Tag.Key, 0x1221, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_128S_PUBLIC = Multicodec.of("slhdsa-shake-128s-pub", Tag.Key, 0x1221, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-192f-priv, SLH-DSA-SHAKE-192f private key; as specified by FIPS 205, status = draft, code = 0x1324 */
-    public static final Multicodec SLHDSA_SHAKE_192F_PRIVATE_KEY = Multicodec.of("slhdsa-shake-192f-priv", Tag.Key, 0x1324, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_192F_PRIVATE = Multicodec.of("slhdsa-shake-192f-priv", Tag.Key, 0x1324, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-192f-pub, SLH-DSA-SHAKE-192f public key; as specified by FIPS 205, status = draft, code = 0x1227 */
-    public static final Multicodec SLHDSA_SHAKE_192F_PUBLIC_KEY = Multicodec.of("slhdsa-shake-192f-pub", Tag.Key, 0x1227, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_192F_PUBLIC = Multicodec.of("slhdsa-shake-192f-pub", Tag.Key, 0x1227, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-192s-priv, SLH-DSA-SHAKE-192s private key; as specified by FIPS 205, status = draft, code = 0x1322 */
-    public static final Multicodec SLHDSA_SHAKE_192S_PRIVATE_KEY = Multicodec.of("slhdsa-shake-192s-priv", Tag.Key, 0x1322, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_192S_PRIVATE = Multicodec.of("slhdsa-shake-192s-priv", Tag.Key, 0x1322, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-192s-pub, SLH-DSA-SHAKE-192s public key; as specified by FIPS 205, status = draft, code = 0x1225 */
-    public static final Multicodec SLHDSA_SHAKE_192S_PUBLIC_KEY = Multicodec.of("slhdsa-shake-192s-pub", Tag.Key, 0x1225, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_192S_PUBLIC = Multicodec.of("slhdsa-shake-192s-pub", Tag.Key, 0x1225, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-256f-priv, SLH-DSA-SHAKE-256f private key; as specified by FIPS 205, status = draft, code = 0x1328 */
-    public static final Multicodec SLHDSA_SHAKE_256F_PRIVATE_KEY = Multicodec.of("slhdsa-shake-256f-priv", Tag.Key, 0x1328, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_256F_PRIVATE = Multicodec.of("slhdsa-shake-256f-priv", Tag.Key, 0x1328, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-256f-pub, SLH-DSA-SHAKE-256f public key; as specified by FIPS 205, status = draft, code = 0x122b */
-    public static final Multicodec SLHDSA_SHAKE_256F_PUBLIC_KEY = Multicodec.of("slhdsa-shake-256f-pub", Tag.Key, 0x122b, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_256F_PUBLIC = Multicodec.of("slhdsa-shake-256f-pub", Tag.Key, 0x122b, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-256s-priv, SLH-DSA-SHAKE-256s private key; as specified by FIPS 205, status = draft, code = 0x1326 */
-    public static final Multicodec SLHDSA_SHAKE_256S_PRIVATE_KEY = Multicodec.of("slhdsa-shake-256s-priv", Tag.Key, 0x1326, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_256S_PRIVATE = Multicodec.of("slhdsa-shake-256s-priv", Tag.Key, 0x1326, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-256s-pub, SLH-DSA-SHAKE-256s public key; as specified by FIPS 205, status = draft, code = 0x1229 */
-    public static final Multicodec SLHDSA_SHAKE_256S_PUBLIC_KEY = Multicodec.of("slhdsa-shake-256s-pub", Tag.Key, 0x1229, Multicodec.Status.Draft);
+    public static final Multicodec SLHDSA_SHAKE_256S_PUBLIC = Multicodec.of("slhdsa-shake-256s-pub", Tag.Key, 0x1229, Multicodec.Status.Draft);
 
     /** Key: sm2-priv, SM2 private key, status = draft, code = 0x1310 */
-    public static final Multicodec SM2_PRIVATE_KEY = Multicodec.of("sm2-priv", Tag.Key, 0x1310, Multicodec.Status.Draft);
+    public static final Multicodec SM2_PRIVATE = Multicodec.of("sm2-priv", Tag.Key, 0x1310, Multicodec.Status.Draft);
 
     /** Key: sm2-pub, SM2 public key (compressed), status = draft, code = 0x1206 */
-    public static final Multicodec SM2_PUBLIC_KEY = Multicodec.of("sm2-pub", Tag.Key, 0x1206, Multicodec.Status.Draft);
+    public static final Multicodec SM2_PUBLIC = Multicodec.of("sm2-pub", Tag.Key, 0x1206, Multicodec.Status.Draft);
 
     /** Key: sr25519-priv, Sr25519 private key, status = draft, code = 0x1303 */
-    public static final Multicodec SR25519_PRIVATE_KEY = Multicodec.of("sr25519-priv", Tag.Key, 0x1303, Multicodec.Status.Draft);
+    public static final Multicodec SR25519_PRIVATE = Multicodec.of("sr25519-priv", Tag.Key, 0x1303, Multicodec.Status.Draft);
 
     /** Key: sr25519-pub, Sr25519 public key, status = draft, code = 0xef */
-    public static final Multicodec SR25519_PUBLIC_KEY = Multicodec.of("sr25519-pub", Tag.Key, 0xef, Multicodec.Status.Draft);
+    public static final Multicodec SR25519_PUBLIC = Multicodec.of("sr25519-pub", Tag.Key, 0xef, Multicodec.Status.Draft);
 
     /** Key: x25519-priv, Curve25519 private key, status = draft, code = 0x1302 */
-    public static final Multicodec X25519_PRIVATE_KEY = Multicodec.of("x25519-priv", Tag.Key, 0x1302, Multicodec.Status.Draft);
+    public static final Multicodec X25519_PRIVATE = Multicodec.of("x25519-priv", Tag.Key, 0x1302, Multicodec.Status.Draft);
 
     /** Key: x25519-pub, Curve25519 public key, status = draft, code = 0xec */
-    public static final Multicodec X25519_PUBLIC_KEY = Multicodec.of("x25519-pub", Tag.Key, 0xec, Multicodec.Status.Draft);
+    public static final Multicodec X25519_PUBLIC = Multicodec.of("x25519-pub", Tag.Key, 0xec, Multicodec.Status.Draft);
 
     /** Key: x448-priv, X448 private key, status = draft, code = 0x1312 */
-    public static final Multicodec X448_PRIVATE_KEY = Multicodec.of("x448-priv", Tag.Key, 0x1312, Multicodec.Status.Draft);
+    public static final Multicodec X448_PRIVATE = Multicodec.of("x448-priv", Tag.Key, 0x1312, Multicodec.Status.Draft);
 
     /** Key: x448-pub, X448 public key, status = draft, code = 0x1204 */
-    public static final Multicodec X448_PUBLIC_KEY = Multicodec.of("x448-pub", Tag.Key, 0x1204, Multicodec.Status.Draft);
+    public static final Multicodec X448_PUBLIC = Multicodec.of("x448-pub", Tag.Key, 0x1204, Multicodec.Status.Draft);
 
     protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
-      ALL.put(AES_128_KEY.code(), AES_128_KEY);
-      ALL.put(AES_192_KEY.code(), AES_192_KEY);
-      ALL.put(AES_256_KEY.code(), AES_256_KEY);
-      ALL.put(BIP340_PRIVATE_KEY.code(), BIP340_PRIVATE_KEY);
-      ALL.put(BIP340_PUBLIC_KEY.code(), BIP340_PUBLIC_KEY);
-      ALL.put(BLS12_381_G1_PRIVATE_KEY.code(), BLS12_381_G1_PRIVATE_KEY);
-      ALL.put(BLS12_381_G1_PRIVATE_SHARE_KEY.code(), BLS12_381_G1_PRIVATE_SHARE_KEY);
-      ALL.put(BLS12_381_G1_PUBLIC_KEY.code(), BLS12_381_G1_PUBLIC_KEY);
-      ALL.put(BLS12_381_G1_PUBLIC_SHARE_KEY.code(), BLS12_381_G1_PUBLIC_SHARE_KEY);
-      ALL.put(BLS12_381_G1G2_PRIVATE_KEY.code(), BLS12_381_G1G2_PRIVATE_KEY);
-      ALL.put(BLS12_381_G1G2_PUBLIC_KEY.code(), BLS12_381_G1G2_PUBLIC_KEY);
-      ALL.put(BLS12_381_G2_PRIVATE_KEY.code(), BLS12_381_G2_PRIVATE_KEY);
-      ALL.put(BLS12_381_G2_PRIVATE_SHARE_KEY.code(), BLS12_381_G2_PRIVATE_SHARE_KEY);
-      ALL.put(BLS12_381_G2_PUBLIC_KEY.code(), BLS12_381_G2_PUBLIC_KEY);
-      ALL.put(BLS12_381_G2_PUBLIC_SHARE_KEY.code(), BLS12_381_G2_PUBLIC_SHARE_KEY);
-      ALL.put(CHACHA_128_KEY.code(), CHACHA_128_KEY);
-      ALL.put(CHACHA_256_KEY.code(), CHACHA_256_KEY);
-      ALL.put(ED25519_PRIVATE_KEY.code(), ED25519_PRIVATE_KEY);
-      ALL.put(ED25519_PUBLIC_KEY.code(), ED25519_PUBLIC_KEY);
-      ALL.put(ED448_PRIVATE_KEY.code(), ED448_PRIVATE_KEY);
-      ALL.put(ED448_PUBLIC_KEY.code(), ED448_PUBLIC_KEY);
-      ALL.put(JWK_JCS_PRIVATE_KEY.code(), JWK_JCS_PRIVATE_KEY);
-      ALL.put(JWK_JCS_PUBLIC_KEY.code(), JWK_JCS_PUBLIC_KEY);
-      ALL.put(LAMPORT_SHA3_256_PRIVATE_KEY.code(), LAMPORT_SHA3_256_PRIVATE_KEY);
-      ALL.put(LAMPORT_SHA3_256_PRIVATE_SHARE_KEY.code(), LAMPORT_SHA3_256_PRIVATE_SHARE_KEY);
-      ALL.put(LAMPORT_SHA3_256_PUBLIC_KEY.code(), LAMPORT_SHA3_256_PUBLIC_KEY);
-      ALL.put(LAMPORT_SHA3_384_PRIVATE_KEY.code(), LAMPORT_SHA3_384_PRIVATE_KEY);
-      ALL.put(LAMPORT_SHA3_384_PRIVATE_SHARE_KEY.code(), LAMPORT_SHA3_384_PRIVATE_SHARE_KEY);
-      ALL.put(LAMPORT_SHA3_384_PUBLIC_KEY.code(), LAMPORT_SHA3_384_PUBLIC_KEY);
-      ALL.put(LAMPORT_SHA3_512_PRIVATE_KEY.code(), LAMPORT_SHA3_512_PRIVATE_KEY);
-      ALL.put(LAMPORT_SHA3_512_PRIVATE_SHARE_KEY.code(), LAMPORT_SHA3_512_PRIVATE_SHARE_KEY);
-      ALL.put(LAMPORT_SHA3_512_PUBLIC_KEY.code(), LAMPORT_SHA3_512_PUBLIC_KEY);
-      ALL.put(MLDSA_44_PRIVATE_KEY.code(), MLDSA_44_PRIVATE_KEY);
-      ALL.put(MLDSA_44_PRIVATE_SEED_KEY.code(), MLDSA_44_PRIVATE_SEED_KEY);
-      ALL.put(MLDSA_44_PUBLIC_KEY.code(), MLDSA_44_PUBLIC_KEY);
-      ALL.put(MLDSA_65_PRIVATE_KEY.code(), MLDSA_65_PRIVATE_KEY);
-      ALL.put(MLDSA_65_PRIVATE_SEED_KEY.code(), MLDSA_65_PRIVATE_SEED_KEY);
-      ALL.put(MLDSA_65_PUBLIC_KEY.code(), MLDSA_65_PUBLIC_KEY);
-      ALL.put(MLDSA_87_PRIVATE_KEY.code(), MLDSA_87_PRIVATE_KEY);
-      ALL.put(MLDSA_87_PRIVATE_SEED_KEY.code(), MLDSA_87_PRIVATE_SEED_KEY);
-      ALL.put(MLDSA_87_PUBLIC_KEY.code(), MLDSA_87_PUBLIC_KEY);
-      ALL.put(MLKEM_1024_PRIVATE_KEY.code(), MLKEM_1024_PRIVATE_KEY);
-      ALL.put(MLKEM_1024_PUBLIC_KEY.code(), MLKEM_1024_PUBLIC_KEY);
-      ALL.put(MLKEM_512_PRIVATE_KEY.code(), MLKEM_512_PRIVATE_KEY);
-      ALL.put(MLKEM_512_PUBLIC_KEY.code(), MLKEM_512_PUBLIC_KEY);
-      ALL.put(MLKEM_768_PRIVATE_KEY.code(), MLKEM_768_PRIVATE_KEY);
-      ALL.put(MLKEM_768_PUBLIC_KEY.code(), MLKEM_768_PUBLIC_KEY);
-      ALL.put(P256_PRIVATE_KEY.code(), P256_PRIVATE_KEY);
-      ALL.put(P256_PUBLIC_KEY.code(), P256_PUBLIC_KEY);
-      ALL.put(P384_PRIVATE_KEY.code(), P384_PRIVATE_KEY);
-      ALL.put(P384_PUBLIC_KEY.code(), P384_PUBLIC_KEY);
-      ALL.put(P521_PRIVATE_KEY.code(), P521_PRIVATE_KEY);
-      ALL.put(P521_PUBLIC_KEY.code(), P521_PUBLIC_KEY);
-      ALL.put(RSA_PRIVATE_KEY.code(), RSA_PRIVATE_KEY);
-      ALL.put(RSA_PUBLIC_KEY.code(), RSA_PUBLIC_KEY);
-      ALL.put(SECP256K1_PRIVATE_KEY.code(), SECP256K1_PRIVATE_KEY);
-      ALL.put(SECP256K1_PUBLIC_KEY.code(), SECP256K1_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHA2_128F_PRIVATE_KEY.code(), SLHDSA_SHA2_128F_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHA2_128F_PUBLIC_KEY.code(), SLHDSA_SHA2_128F_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHA2_128S_PRIVATE_KEY.code(), SLHDSA_SHA2_128S_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHA2_128S_PUBLIC_KEY.code(), SLHDSA_SHA2_128S_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHA2_192F_PRIVATE_KEY.code(), SLHDSA_SHA2_192F_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHA2_192F_PUBLIC_KEY.code(), SLHDSA_SHA2_192F_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHA2_192S_PRIVATE_KEY.code(), SLHDSA_SHA2_192S_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHA2_192S_PUBLIC_KEY.code(), SLHDSA_SHA2_192S_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHA2_256F_PRIVATE_KEY.code(), SLHDSA_SHA2_256F_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHA2_256F_PUBLIC_KEY.code(), SLHDSA_SHA2_256F_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHA2_256S_PRIVATE_KEY.code(), SLHDSA_SHA2_256S_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHA2_256S_PUBLIC_KEY.code(), SLHDSA_SHA2_256S_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHAKE_128F_PRIVATE_KEY.code(), SLHDSA_SHAKE_128F_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHAKE_128F_PUBLIC_KEY.code(), SLHDSA_SHAKE_128F_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHAKE_128S_PRIVATE_KEY.code(), SLHDSA_SHAKE_128S_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHAKE_128S_PUBLIC_KEY.code(), SLHDSA_SHAKE_128S_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHAKE_192F_PRIVATE_KEY.code(), SLHDSA_SHAKE_192F_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHAKE_192F_PUBLIC_KEY.code(), SLHDSA_SHAKE_192F_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHAKE_192S_PRIVATE_KEY.code(), SLHDSA_SHAKE_192S_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHAKE_192S_PUBLIC_KEY.code(), SLHDSA_SHAKE_192S_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHAKE_256F_PRIVATE_KEY.code(), SLHDSA_SHAKE_256F_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHAKE_256F_PUBLIC_KEY.code(), SLHDSA_SHAKE_256F_PUBLIC_KEY);
-      ALL.put(SLHDSA_SHAKE_256S_PRIVATE_KEY.code(), SLHDSA_SHAKE_256S_PRIVATE_KEY);
-      ALL.put(SLHDSA_SHAKE_256S_PUBLIC_KEY.code(), SLHDSA_SHAKE_256S_PUBLIC_KEY);
-      ALL.put(SM2_PRIVATE_KEY.code(), SM2_PRIVATE_KEY);
-      ALL.put(SM2_PUBLIC_KEY.code(), SM2_PUBLIC_KEY);
-      ALL.put(SR25519_PRIVATE_KEY.code(), SR25519_PRIVATE_KEY);
-      ALL.put(SR25519_PUBLIC_KEY.code(), SR25519_PUBLIC_KEY);
-      ALL.put(X25519_PRIVATE_KEY.code(), X25519_PRIVATE_KEY);
-      ALL.put(X25519_PUBLIC_KEY.code(), X25519_PUBLIC_KEY);
-      ALL.put(X448_PRIVATE_KEY.code(), X448_PRIVATE_KEY);
-      ALL.put(X448_PUBLIC_KEY.code(), X448_PUBLIC_KEY);
+      ALL.put(AES_128.code(), AES_128);
+      ALL.put(AES_192.code(), AES_192);
+      ALL.put(AES_256.code(), AES_256);
+      ALL.put(BIP340_PRIVATE.code(), BIP340_PRIVATE);
+      ALL.put(BIP340_PUBLIC.code(), BIP340_PUBLIC);
+      ALL.put(BLS12_381_G1_PRIVATE.code(), BLS12_381_G1_PRIVATE);
+      ALL.put(BLS12_381_G1_PRIVATE_SHARE.code(), BLS12_381_G1_PRIVATE_SHARE);
+      ALL.put(BLS12_381_G1_PUBLIC.code(), BLS12_381_G1_PUBLIC);
+      ALL.put(BLS12_381_G1_PUBLIC_SHARE.code(), BLS12_381_G1_PUBLIC_SHARE);
+      ALL.put(BLS12_381_G1G2_PRIVATE.code(), BLS12_381_G1G2_PRIVATE);
+      ALL.put(BLS12_381_G1G2_PUBLIC.code(), BLS12_381_G1G2_PUBLIC);
+      ALL.put(BLS12_381_G2_PRIVATE.code(), BLS12_381_G2_PRIVATE);
+      ALL.put(BLS12_381_G2_PRIVATE_SHARE.code(), BLS12_381_G2_PRIVATE_SHARE);
+      ALL.put(BLS12_381_G2_PUBLIC.code(), BLS12_381_G2_PUBLIC);
+      ALL.put(BLS12_381_G2_PUBLIC_SHARE.code(), BLS12_381_G2_PUBLIC_SHARE);
+      ALL.put(CHACHA_128.code(), CHACHA_128);
+      ALL.put(CHACHA_256.code(), CHACHA_256);
+      ALL.put(ED25519_PRIVATE.code(), ED25519_PRIVATE);
+      ALL.put(ED25519_PUBLIC.code(), ED25519_PUBLIC);
+      ALL.put(ED448_PRIVATE.code(), ED448_PRIVATE);
+      ALL.put(ED448_PUBLIC.code(), ED448_PUBLIC);
+      ALL.put(JWK_JCS_PRIVATE.code(), JWK_JCS_PRIVATE);
+      ALL.put(JWK_JCS_PUBLIC.code(), JWK_JCS_PUBLIC);
+      ALL.put(LAMPORT_SHA3_256_PRIVATE.code(), LAMPORT_SHA3_256_PRIVATE);
+      ALL.put(LAMPORT_SHA3_256_PRIVATE_SHARE.code(), LAMPORT_SHA3_256_PRIVATE_SHARE);
+      ALL.put(LAMPORT_SHA3_256_PUBLIC.code(), LAMPORT_SHA3_256_PUBLIC);
+      ALL.put(LAMPORT_SHA3_384_PRIVATE.code(), LAMPORT_SHA3_384_PRIVATE);
+      ALL.put(LAMPORT_SHA3_384_PRIVATE_SHARE.code(), LAMPORT_SHA3_384_PRIVATE_SHARE);
+      ALL.put(LAMPORT_SHA3_384_PUBLIC.code(), LAMPORT_SHA3_384_PUBLIC);
+      ALL.put(LAMPORT_SHA3_512_PRIVATE.code(), LAMPORT_SHA3_512_PRIVATE);
+      ALL.put(LAMPORT_SHA3_512_PRIVATE_SHARE.code(), LAMPORT_SHA3_512_PRIVATE_SHARE);
+      ALL.put(LAMPORT_SHA3_512_PUBLIC.code(), LAMPORT_SHA3_512_PUBLIC);
+      ALL.put(MLDSA_44_PRIVATE.code(), MLDSA_44_PRIVATE);
+      ALL.put(MLDSA_44_PRIVATE_SEED.code(), MLDSA_44_PRIVATE_SEED);
+      ALL.put(MLDSA_44_PUBLIC.code(), MLDSA_44_PUBLIC);
+      ALL.put(MLDSA_65_PRIVATE.code(), MLDSA_65_PRIVATE);
+      ALL.put(MLDSA_65_PRIVATE_SEED.code(), MLDSA_65_PRIVATE_SEED);
+      ALL.put(MLDSA_65_PUBLIC.code(), MLDSA_65_PUBLIC);
+      ALL.put(MLDSA_87_PRIVATE.code(), MLDSA_87_PRIVATE);
+      ALL.put(MLDSA_87_PRIVATE_SEED.code(), MLDSA_87_PRIVATE_SEED);
+      ALL.put(MLDSA_87_PUBLIC.code(), MLDSA_87_PUBLIC);
+      ALL.put(MLKEM_1024_PRIVATE.code(), MLKEM_1024_PRIVATE);
+      ALL.put(MLKEM_1024_PUBLIC.code(), MLKEM_1024_PUBLIC);
+      ALL.put(MLKEM_512_PRIVATE.code(), MLKEM_512_PRIVATE);
+      ALL.put(MLKEM_512_PUBLIC.code(), MLKEM_512_PUBLIC);
+      ALL.put(MLKEM_768_PRIVATE.code(), MLKEM_768_PRIVATE);
+      ALL.put(MLKEM_768_PUBLIC.code(), MLKEM_768_PUBLIC);
+      ALL.put(P256_PRIVATE.code(), P256_PRIVATE);
+      ALL.put(P256_PUBLIC.code(), P256_PUBLIC);
+      ALL.put(P384_PRIVATE.code(), P384_PRIVATE);
+      ALL.put(P384_PUBLIC.code(), P384_PUBLIC);
+      ALL.put(P521_PRIVATE.code(), P521_PRIVATE);
+      ALL.put(P521_PUBLIC.code(), P521_PUBLIC);
+      ALL.put(RSA_PRIVATE.code(), RSA_PRIVATE);
+      ALL.put(RSA_PUBLIC.code(), RSA_PUBLIC);
+      ALL.put(SECP256K1_PRIVATE.code(), SECP256K1_PRIVATE);
+      ALL.put(SECP256K1_PUBLIC.code(), SECP256K1_PUBLIC);
+      ALL.put(SLHDSA_SHA2_128F_PRIVATE.code(), SLHDSA_SHA2_128F_PRIVATE);
+      ALL.put(SLHDSA_SHA2_128F_PUBLIC.code(), SLHDSA_SHA2_128F_PUBLIC);
+      ALL.put(SLHDSA_SHA2_128S_PRIVATE.code(), SLHDSA_SHA2_128S_PRIVATE);
+      ALL.put(SLHDSA_SHA2_128S_PUBLIC.code(), SLHDSA_SHA2_128S_PUBLIC);
+      ALL.put(SLHDSA_SHA2_192F_PRIVATE.code(), SLHDSA_SHA2_192F_PRIVATE);
+      ALL.put(SLHDSA_SHA2_192F_PUBLIC.code(), SLHDSA_SHA2_192F_PUBLIC);
+      ALL.put(SLHDSA_SHA2_192S_PRIVATE.code(), SLHDSA_SHA2_192S_PRIVATE);
+      ALL.put(SLHDSA_SHA2_192S_PUBLIC.code(), SLHDSA_SHA2_192S_PUBLIC);
+      ALL.put(SLHDSA_SHA2_256F_PRIVATE.code(), SLHDSA_SHA2_256F_PRIVATE);
+      ALL.put(SLHDSA_SHA2_256F_PUBLIC.code(), SLHDSA_SHA2_256F_PUBLIC);
+      ALL.put(SLHDSA_SHA2_256S_PRIVATE.code(), SLHDSA_SHA2_256S_PRIVATE);
+      ALL.put(SLHDSA_SHA2_256S_PUBLIC.code(), SLHDSA_SHA2_256S_PUBLIC);
+      ALL.put(SLHDSA_SHAKE_128F_PRIVATE.code(), SLHDSA_SHAKE_128F_PRIVATE);
+      ALL.put(SLHDSA_SHAKE_128F_PUBLIC.code(), SLHDSA_SHAKE_128F_PUBLIC);
+      ALL.put(SLHDSA_SHAKE_128S_PRIVATE.code(), SLHDSA_SHAKE_128S_PRIVATE);
+      ALL.put(SLHDSA_SHAKE_128S_PUBLIC.code(), SLHDSA_SHAKE_128S_PUBLIC);
+      ALL.put(SLHDSA_SHAKE_192F_PRIVATE.code(), SLHDSA_SHAKE_192F_PRIVATE);
+      ALL.put(SLHDSA_SHAKE_192F_PUBLIC.code(), SLHDSA_SHAKE_192F_PUBLIC);
+      ALL.put(SLHDSA_SHAKE_192S_PRIVATE.code(), SLHDSA_SHAKE_192S_PRIVATE);
+      ALL.put(SLHDSA_SHAKE_192S_PUBLIC.code(), SLHDSA_SHAKE_192S_PUBLIC);
+      ALL.put(SLHDSA_SHAKE_256F_PRIVATE.code(), SLHDSA_SHAKE_256F_PRIVATE);
+      ALL.put(SLHDSA_SHAKE_256F_PUBLIC.code(), SLHDSA_SHAKE_256F_PUBLIC);
+      ALL.put(SLHDSA_SHAKE_256S_PRIVATE.code(), SLHDSA_SHAKE_256S_PRIVATE);
+      ALL.put(SLHDSA_SHAKE_256S_PUBLIC.code(), SLHDSA_SHAKE_256S_PUBLIC);
+      ALL.put(SM2_PRIVATE.code(), SM2_PRIVATE);
+      ALL.put(SM2_PUBLIC.code(), SM2_PUBLIC);
+      ALL.put(SR25519_PRIVATE.code(), SR25519_PRIVATE);
+      ALL.put(SR25519_PUBLIC.code(), SR25519_PUBLIC);
+      ALL.put(X25519_PRIVATE.code(), X25519_PRIVATE);
+      ALL.put(X25519_PUBLIC.code(), X25519_PUBLIC);
+      ALL.put(X448_PRIVATE.code(), X448_PRIVATE);
+      ALL.put(X448_PUBLIC.code(), X448_PUBLIC);
     }
 
     protected KeyCodec() { /* protected */ }

--- a/src/main/java/com/apicatalog/multicodec/codec/KeyCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/KeyCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jun 01 18:59:15 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 22:44:55 CEST 2026 */
 public class KeyCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-06-01T16:59:15.506Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:55.886Z");
 
     /** Key: aes-128, 128-bit AES symmetric key, status = draft, code = 0xa0 */
     public static final Multicodec AES_128_KEY = Multicodec.of("aes-128", Tag.Key, 0xa0, Multicodec.Status.Draft);
@@ -72,7 +72,7 @@ public class KeyCodec {
     /** Key: ed448-priv, Ed448 private key, status = draft, code = 0x1311 */
     public static final Multicodec ED448_PRIVATE_KEY = Multicodec.of("ed448-priv", Tag.Key, 0x1311, Multicodec.Status.Draft);
 
-    /** Key: ed448-pub, Ed448 public Key, status = draft, code = 0x1203 */
+    /** Key: ed448-pub, Ed448 public key, status = draft, code = 0x1203 */
     public static final Multicodec ED448_PUBLIC_KEY = Multicodec.of("ed448-pub", Tag.Key, 0x1203, Multicodec.Status.Draft);
 
     /** Key: jwk_jcs-priv, JSON object containing only the required members of a JWK (RFC 7518 and RFC 7517) representing the private key. Serialisation based on JCS (RFC 8785), status = draft, code = 0x1316 */
@@ -135,7 +135,7 @@ public class KeyCodec {
     /** Key: mldsa-87-pub, ML-DSA 87 public key; as specified by FIPS 204, status = draft, code = 0x1212 */
     public static final Multicodec MLDSA_87_PUBLIC_KEY = Multicodec.of("mldsa-87-pub", Tag.Key, 0x1212, Multicodec.Status.Draft);
 
-    /** Key: mlkem-1024-priv, ML-KEM 1024 public key; as specified by FIPS 203, status = draft, code = 0x1315 */
+    /** Key: mlkem-1024-priv, ML-KEM 1024 private key; as specified by FIPS 203, status = draft, code = 0x1315 */
     public static final Multicodec MLKEM_1024_PRIVATE_KEY = Multicodec.of("mlkem-1024-priv", Tag.Key, 0x1315, Multicodec.Status.Draft);
 
     /** Key: mlkem-1024-pub, ML-KEM 1024 public key; as specified by FIPS 203, status = draft, code = 0x120d */
@@ -147,7 +147,7 @@ public class KeyCodec {
     /** Key: mlkem-512-pub, ML-KEM 512 public key; as specified by FIPS 203, status = draft, code = 0x120b */
     public static final Multicodec MLKEM_512_PUBLIC_KEY = Multicodec.of("mlkem-512-pub", Tag.Key, 0x120b, Multicodec.Status.Draft);
 
-    /** Key: mlkem-768-priv, ML-KEM 768 public key; as specified by FIPS 203, status = draft, code = 0x1314 */
+    /** Key: mlkem-768-priv, ML-KEM 768 private key; as specified by FIPS 203, status = draft, code = 0x1314 */
     public static final Multicodec MLKEM_768_PRIVATE_KEY = Multicodec.of("mlkem-768-priv", Tag.Key, 0x1314, Multicodec.Status.Draft);
 
     /** Key: mlkem-768-pub, ML-KEM 768 public key; as specified by FIPS 203, status = draft, code = 0x120c */
@@ -156,19 +156,19 @@ public class KeyCodec {
     /** Key: p256-priv, P-256 private key, status = draft, code = 0x1306 */
     public static final Multicodec P256_PRIVATE_KEY = Multicodec.of("p256-priv", Tag.Key, 0x1306, Multicodec.Status.Draft);
 
-    /** Key: p256-pub, P-256 public Key (compressed), status = draft, code = 0x1200 */
+    /** Key: p256-pub, P-256 public key (compressed), status = draft, code = 0x1200 */
     public static final Multicodec P256_PUBLIC_KEY = Multicodec.of("p256-pub", Tag.Key, 0x1200, Multicodec.Status.Draft);
 
     /** Key: p384-priv, P-384 private key, status = draft, code = 0x1307 */
     public static final Multicodec P384_PRIVATE_KEY = Multicodec.of("p384-priv", Tag.Key, 0x1307, Multicodec.Status.Draft);
 
-    /** Key: p384-pub, P-384 public Key (compressed), status = draft, code = 0x1201 */
+    /** Key: p384-pub, P-384 public key (compressed), status = draft, code = 0x1201 */
     public static final Multicodec P384_PUBLIC_KEY = Multicodec.of("p384-pub", Tag.Key, 0x1201, Multicodec.Status.Draft);
 
     /** Key: p521-priv, P-521 private key, status = draft, code = 0x1308 */
     public static final Multicodec P521_PRIVATE_KEY = Multicodec.of("p521-priv", Tag.Key, 0x1308, Multicodec.Status.Draft);
 
-    /** Key: p521-pub, P-521 public Key (compressed), status = draft, code = 0x1202 */
+    /** Key: p521-pub, P-521 public key (compressed), status = draft, code = 0x1202 */
     public static final Multicodec P521_PUBLIC_KEY = Multicodec.of("p521-pub", Tag.Key, 0x1202, Multicodec.Status.Draft);
 
     /** Key: rsa-priv, RSA private key, status = draft, code = 0x1305 */
@@ -183,38 +183,74 @@ public class KeyCodec {
     /** Key: secp256k1-pub, Secp256k1 public key (compressed), status = draft, code = 0xe7 */
     public static final Multicodec SECP256K1_PUBLIC_KEY = Multicodec.of("secp256k1-pub", Tag.Key, 0xe7, Multicodec.Status.Draft);
 
+    /** Key: slhdsa-sha2-128f-priv, SLH-DSA-SHA2-128f private key; as specified by FIPS 205, status = draft, code = 0x131f */
+    public static final Multicodec SLHDSA_SHA2_128F_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-128f-priv", Tag.Key, 0x131f, Multicodec.Status.Draft);
+
     /** Key: slhdsa-sha2-128f-pub, SLH-DSA-SHA2-128f public key; as specified by FIPS 205, status = draft, code = 0x1222 */
     public static final Multicodec SLHDSA_SHA2_128F_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-128f-pub", Tag.Key, 0x1222, Multicodec.Status.Draft);
+
+    /** Key: slhdsa-sha2-128s-priv, SLH-DSA-SHA2-128s private key; as specified by FIPS 205, status = draft, code = 0x131d */
+    public static final Multicodec SLHDSA_SHA2_128S_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-128s-priv", Tag.Key, 0x131d, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-128s-pub, SLH-DSA-SHA2-128s public key; as specified by FIPS 205, status = draft, code = 0x1220 */
     public static final Multicodec SLHDSA_SHA2_128S_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-128s-pub", Tag.Key, 0x1220, Multicodec.Status.Draft);
 
+    /** Key: slhdsa-sha2-192f-priv, SLH-DSA-SHA2-192f private key; as specified by FIPS 205, status = draft, code = 0x1323 */
+    public static final Multicodec SLHDSA_SHA2_192F_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-192f-priv", Tag.Key, 0x1323, Multicodec.Status.Draft);
+
     /** Key: slhdsa-sha2-192f-pub, SLH-DSA-SHA2-192f public key; as specified by FIPS 205, status = draft, code = 0x1226 */
     public static final Multicodec SLHDSA_SHA2_192F_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-192f-pub", Tag.Key, 0x1226, Multicodec.Status.Draft);
+
+    /** Key: slhdsa-sha2-192s-priv, SLH-DSA-SHA2-192s private key; as specified by FIPS 205, status = draft, code = 0x1321 */
+    public static final Multicodec SLHDSA_SHA2_192S_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-192s-priv", Tag.Key, 0x1321, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-192s-pub, SLH-DSA-SHA2-192s public key; as specified by FIPS 205, status = draft, code = 0x1224 */
     public static final Multicodec SLHDSA_SHA2_192S_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-192s-pub", Tag.Key, 0x1224, Multicodec.Status.Draft);
 
+    /** Key: slhdsa-sha2-256f-priv, SLH-DSA-SHA2-256f private key; as specified by FIPS 205, status = draft, code = 0x1327 */
+    public static final Multicodec SLHDSA_SHA2_256F_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-256f-priv", Tag.Key, 0x1327, Multicodec.Status.Draft);
+
     /** Key: slhdsa-sha2-256f-pub, SLH-DSA-SHA2-256f public key; as specified by FIPS 205, status = draft, code = 0x122a */
     public static final Multicodec SLHDSA_SHA2_256F_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-256f-pub", Tag.Key, 0x122a, Multicodec.Status.Draft);
+
+    /** Key: slhdsa-sha2-256s-priv, SLH-DSA-SHA2-256s private key; as specified by FIPS 205, status = draft, code = 0x1325 */
+    public static final Multicodec SLHDSA_SHA2_256S_PRIVATE_KEY = Multicodec.of("slhdsa-sha2-256s-priv", Tag.Key, 0x1325, Multicodec.Status.Draft);
 
     /** Key: slhdsa-sha2-256s-pub, SLH-DSA-SHA2-256s public key; as specified by FIPS 205, status = draft, code = 0x1228 */
     public static final Multicodec SLHDSA_SHA2_256S_PUBLIC_KEY = Multicodec.of("slhdsa-sha2-256s-pub", Tag.Key, 0x1228, Multicodec.Status.Draft);
 
+    /** Key: slhdsa-shake-128f-priv, SLH-DSA-SHAKE-128f private key; as specified by FIPS 205, status = draft, code = 0x1320 */
+    public static final Multicodec SLHDSA_SHAKE_128F_PRIVATE_KEY = Multicodec.of("slhdsa-shake-128f-priv", Tag.Key, 0x1320, Multicodec.Status.Draft);
+
     /** Key: slhdsa-shake-128f-pub, SLH-DSA-SHAKE-128f public key; as specified by FIPS 205, status = draft, code = 0x1223 */
     public static final Multicodec SLHDSA_SHAKE_128F_PUBLIC_KEY = Multicodec.of("slhdsa-shake-128f-pub", Tag.Key, 0x1223, Multicodec.Status.Draft);
+
+    /** Key: slhdsa-shake-128s-priv, SLH-DSA-SHAKE-128s private key; as specified by FIPS 205, status = draft, code = 0x131e */
+    public static final Multicodec SLHDSA_SHAKE_128S_PRIVATE_KEY = Multicodec.of("slhdsa-shake-128s-priv", Tag.Key, 0x131e, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-128s-pub, SLH-DSA-SHAKE-128s public key; as specified by FIPS 205, status = draft, code = 0x1221 */
     public static final Multicodec SLHDSA_SHAKE_128S_PUBLIC_KEY = Multicodec.of("slhdsa-shake-128s-pub", Tag.Key, 0x1221, Multicodec.Status.Draft);
 
+    /** Key: slhdsa-shake-192f-priv, SLH-DSA-SHAKE-192f private key; as specified by FIPS 205, status = draft, code = 0x1324 */
+    public static final Multicodec SLHDSA_SHAKE_192F_PRIVATE_KEY = Multicodec.of("slhdsa-shake-192f-priv", Tag.Key, 0x1324, Multicodec.Status.Draft);
+
     /** Key: slhdsa-shake-192f-pub, SLH-DSA-SHAKE-192f public key; as specified by FIPS 205, status = draft, code = 0x1227 */
     public static final Multicodec SLHDSA_SHAKE_192F_PUBLIC_KEY = Multicodec.of("slhdsa-shake-192f-pub", Tag.Key, 0x1227, Multicodec.Status.Draft);
+
+    /** Key: slhdsa-shake-192s-priv, SLH-DSA-SHAKE-192s private key; as specified by FIPS 205, status = draft, code = 0x1322 */
+    public static final Multicodec SLHDSA_SHAKE_192S_PRIVATE_KEY = Multicodec.of("slhdsa-shake-192s-priv", Tag.Key, 0x1322, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-192s-pub, SLH-DSA-SHAKE-192s public key; as specified by FIPS 205, status = draft, code = 0x1225 */
     public static final Multicodec SLHDSA_SHAKE_192S_PUBLIC_KEY = Multicodec.of("slhdsa-shake-192s-pub", Tag.Key, 0x1225, Multicodec.Status.Draft);
 
+    /** Key: slhdsa-shake-256f-priv, SLH-DSA-SHAKE-256f private key; as specified by FIPS 205, status = draft, code = 0x1328 */
+    public static final Multicodec SLHDSA_SHAKE_256F_PRIVATE_KEY = Multicodec.of("slhdsa-shake-256f-priv", Tag.Key, 0x1328, Multicodec.Status.Draft);
+
     /** Key: slhdsa-shake-256f-pub, SLH-DSA-SHAKE-256f public key; as specified by FIPS 205, status = draft, code = 0x122b */
     public static final Multicodec SLHDSA_SHAKE_256F_PUBLIC_KEY = Multicodec.of("slhdsa-shake-256f-pub", Tag.Key, 0x122b, Multicodec.Status.Draft);
+
+    /** Key: slhdsa-shake-256s-priv, SLH-DSA-SHAKE-256s private key; as specified by FIPS 205, status = draft, code = 0x1326 */
+    public static final Multicodec SLHDSA_SHAKE_256S_PRIVATE_KEY = Multicodec.of("slhdsa-shake-256s-priv", Tag.Key, 0x1326, Multicodec.Status.Draft);
 
     /** Key: slhdsa-shake-256s-pub, SLH-DSA-SHAKE-256s public key; as specified by FIPS 205, status = draft, code = 0x1229 */
     public static final Multicodec SLHDSA_SHAKE_256S_PUBLIC_KEY = Multicodec.of("slhdsa-shake-256s-pub", Tag.Key, 0x1229, Multicodec.Status.Draft);
@@ -240,10 +276,10 @@ public class KeyCodec {
     /** Key: x448-priv, X448 private key, status = draft, code = 0x1312 */
     public static final Multicodec X448_PRIVATE_KEY = Multicodec.of("x448-priv", Tag.Key, 0x1312, Multicodec.Status.Draft);
 
-    /** Key: x448-pub, X448 public Key, status = draft, code = 0x1204 */
+    /** Key: x448-pub, X448 public key, status = draft, code = 0x1204 */
     public static final Multicodec X448_PUBLIC_KEY = Multicodec.of("x448-pub", Tag.Key, 0x1204, Multicodec.Status.Draft);
 
-    protected static final Map<Long,Multicodec> ALL = new TreeMap<>();
+    protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
       ALL.put(AES_128_KEY.code(), AES_128_KEY);
@@ -303,17 +339,29 @@ public class KeyCodec {
       ALL.put(RSA_PUBLIC_KEY.code(), RSA_PUBLIC_KEY);
       ALL.put(SECP256K1_PRIVATE_KEY.code(), SECP256K1_PRIVATE_KEY);
       ALL.put(SECP256K1_PUBLIC_KEY.code(), SECP256K1_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHA2_128F_PRIVATE_KEY.code(), SLHDSA_SHA2_128F_PRIVATE_KEY);
       ALL.put(SLHDSA_SHA2_128F_PUBLIC_KEY.code(), SLHDSA_SHA2_128F_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHA2_128S_PRIVATE_KEY.code(), SLHDSA_SHA2_128S_PRIVATE_KEY);
       ALL.put(SLHDSA_SHA2_128S_PUBLIC_KEY.code(), SLHDSA_SHA2_128S_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHA2_192F_PRIVATE_KEY.code(), SLHDSA_SHA2_192F_PRIVATE_KEY);
       ALL.put(SLHDSA_SHA2_192F_PUBLIC_KEY.code(), SLHDSA_SHA2_192F_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHA2_192S_PRIVATE_KEY.code(), SLHDSA_SHA2_192S_PRIVATE_KEY);
       ALL.put(SLHDSA_SHA2_192S_PUBLIC_KEY.code(), SLHDSA_SHA2_192S_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHA2_256F_PRIVATE_KEY.code(), SLHDSA_SHA2_256F_PRIVATE_KEY);
       ALL.put(SLHDSA_SHA2_256F_PUBLIC_KEY.code(), SLHDSA_SHA2_256F_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHA2_256S_PRIVATE_KEY.code(), SLHDSA_SHA2_256S_PRIVATE_KEY);
       ALL.put(SLHDSA_SHA2_256S_PUBLIC_KEY.code(), SLHDSA_SHA2_256S_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHAKE_128F_PRIVATE_KEY.code(), SLHDSA_SHAKE_128F_PRIVATE_KEY);
       ALL.put(SLHDSA_SHAKE_128F_PUBLIC_KEY.code(), SLHDSA_SHAKE_128F_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHAKE_128S_PRIVATE_KEY.code(), SLHDSA_SHAKE_128S_PRIVATE_KEY);
       ALL.put(SLHDSA_SHAKE_128S_PUBLIC_KEY.code(), SLHDSA_SHAKE_128S_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHAKE_192F_PRIVATE_KEY.code(), SLHDSA_SHAKE_192F_PRIVATE_KEY);
       ALL.put(SLHDSA_SHAKE_192F_PUBLIC_KEY.code(), SLHDSA_SHAKE_192F_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHAKE_192S_PRIVATE_KEY.code(), SLHDSA_SHAKE_192S_PRIVATE_KEY);
       ALL.put(SLHDSA_SHAKE_192S_PUBLIC_KEY.code(), SLHDSA_SHAKE_192S_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHAKE_256F_PRIVATE_KEY.code(), SLHDSA_SHAKE_256F_PRIVATE_KEY);
       ALL.put(SLHDSA_SHAKE_256F_PUBLIC_KEY.code(), SLHDSA_SHAKE_256F_PUBLIC_KEY);
+      ALL.put(SLHDSA_SHAKE_256S_PRIVATE_KEY.code(), SLHDSA_SHAKE_256S_PRIVATE_KEY);
       ALL.put(SLHDSA_SHAKE_256S_PUBLIC_KEY.code(), SLHDSA_SHAKE_256S_PUBLIC_KEY);
       ALL.put(SM2_PRIVATE_KEY.code(), SM2_PRIVATE_KEY);
       ALL.put(SM2_PUBLIC_KEY.code(), SM2_PUBLIC_KEY);

--- a/src/main/java/com/apicatalog/multicodec/codec/MultiaddrCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/MultiaddrCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jun 01 18:59:15 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 22:44:55 CEST 2026 */
 public class MultiaddrCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-06-01T16:59:15.572Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:55.993Z");
 
     /** Multiaddr: certhash, TLS certificate's fingerprint as a multihash, status = draft, code = 0x1d2 */
     public static final Multicodec CERTHASH = Multicodec.of("certhash", Tag.Multiaddr, 0x1d2, Multicodec.Status.Draft);
@@ -144,7 +144,7 @@ public class MultiaddrCodec {
     /** Multiaddr: wss, status = permanent, code = 0x1de */
     public static final Multicodec WSS = Multicodec.of("wss", Tag.Multiaddr, 0x1de, Multicodec.Status.Permanent);
 
-    protected static final Map<Long,Multicodec> ALL = new TreeMap<>();
+    protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
       ALL.put(CERTHASH.code(), CERTHASH);

--- a/src/main/java/com/apicatalog/multicodec/codec/MultiaddrCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/MultiaddrCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jul 06 22:44:55 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 23:11:10 CEST 2026 */
 public class MultiaddrCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:55.993Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T21:11:10.632117595Z");
 
     /** Multiaddr: certhash, TLS certificate's fingerprint as a multihash, status = draft, code = 0x1d2 */
     public static final Multicodec CERTHASH = Multicodec.of("certhash", Tag.Multiaddr, 0x1d2, Multicodec.Status.Draft);

--- a/src/main/java/com/apicatalog/multicodec/codec/MulticodecRegistry.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/MulticodecRegistry.java
@@ -31,13 +31,13 @@ public final class MulticodecRegistry {
     /**
      * Mapping from codec tag to the codecs within that category.
      */
-    private static final Map<Tag, Map<Long, Multicodec>> TAGS;
+    private static final Map<Tag, Map<Integer, Multicodec>> TAGS;
 
     /**
      * Mapping from codec numeric code to its {@link Multicodec} definition across
      * all tags.
      */
-    private static final Map<Long, Multicodec> CODECS;
+    private static final Map<Integer, Multicodec> CODECS;
 
     /**
      * Singleton instance containing all known codecs.
@@ -65,14 +65,14 @@ public final class MulticodecRegistry {
         INSTANCE = new MulticodecRegistry(CODECS);
     }
 
-    private final Map<Long, Multicodec> codecs;
+    private final Map<Integer, Multicodec> codecs;
 
     /**
      * Creates a new registry instance backed by the provided codec mapping.
      *
      * @param codecs a map of numeric codes to codec definitions
      */
-    protected MulticodecRegistry(final Map<Long, Multicodec> codecs) {
+    protected MulticodecRegistry(final Map<Integer, Multicodec> codecs) {
         this.codecs = codecs;
     }
 
@@ -120,7 +120,7 @@ public final class MulticodecRegistry {
      *
      * @return map of numeric code to codec definition
      */
-    public static final Map<Long, Multicodec> provided() {
+    public static final Map<Integer, Multicodec> provided() {
         return CODECS;
     }
 
@@ -130,7 +130,7 @@ public final class MulticodecRegistry {
      * @param tags one or more codec tags to filter by
      * @return map of numeric code to codec definition for matching tags
      */
-    public static final Map<Long, Multicodec> provided(final Tag... tags) {
+    public static final Map<Integer, Multicodec> provided(final Tag... tags) {
         if (tags == null || tags.length == 0) {
             throw new IllegalArgumentException("At least one tag must be provided.");
         }
@@ -150,7 +150,7 @@ public final class MulticodecRegistry {
      * @return an {@link Optional} containing the codec if found, or empty if no
      *         match exists
      */
-    public final Optional<Multicodec> getCodec(final long code) {
+    public final Optional<Multicodec> getCodec(final int code) {
         return Optional.ofNullable(codecs.get(code));
     }
 
@@ -176,7 +176,7 @@ public final class MulticodecRegistry {
      *
      * @return map of numeric code to codec definition
      */
-    public Map<Long, Multicodec> codecs() {
+    public Map<Integer, Multicodec> codecs() {
         return codecs;
     }
 

--- a/src/main/java/com/apicatalog/multicodec/codec/MultiformatCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/MultiformatCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jun 01 18:59:15 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
 public class MultiformatCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-06-01T16:59:15.580Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.012Z");
 
     /** Multiformat: caip-50, CAIP-50 multi-chain account ID, status = draft, code = 0xca */
     public static final Multicodec CAIP_50 = Multicodec.of("caip-50", Tag.Multiformat, 0xca, Multicodec.Status.Draft);
@@ -39,7 +39,7 @@ public class MultiformatCodec {
     /** Multiformat: varsig, Variable signature (varsig) multiformat, status = draft, code = 0x34 */
     public static final Multicodec VARSIG = Multicodec.of("varsig", Tag.Multiformat, 0x34, Multicodec.Status.Draft);
 
-    protected static final Map<Long,Multicodec> ALL = new TreeMap<>();
+    protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
       ALL.put(CAIP_50.code(), CAIP_50);

--- a/src/main/java/com/apicatalog/multicodec/codec/MultiformatCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/MultiformatCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 23:11:10 CEST 2026 */
 public class MultiformatCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.012Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T21:11:10.643206936Z");
 
     /** Multiformat: caip-50, CAIP-50 multi-chain account ID, status = draft, code = 0xca */
     public static final Multicodec CAIP_50 = Multicodec.of("caip-50", Tag.Multiformat, 0xca, Multicodec.Status.Draft);

--- a/src/main/java/com/apicatalog/multicodec/codec/MultihashCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/MultihashCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec;
 import com.apicatalog.multihash.Multihash;
 
-/** Multicodec Registry - generated: Mon Jun 01 18:59:15 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 22:44:55 CEST 2026 */
 public class MultihashCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-06-01T16:59:15.545Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:55.952Z");
 
     /** Multihash: bcrypt-pbkdf, Bcrypt-PBKDF key derivation function, status = draft, code = 0xd00d */
     public static final Multihash BCRYPT_PBKDF = Multihash.of("bcrypt-pbkdf", 0xd00d, Multicodec.Status.Draft);
@@ -320,7 +320,7 @@ public class MultihashCodec {
 
     /** Multihash: identity, raw binary, status = permanent, code = 0x0 */
     public static final Multihash IDENTITY = Multihash.of("identity", 0x0, Multicodec.Status.Permanent);
-    
+
     /** Multihash: keccak-224, keccak has variable output length. The number specifies the core length, status = draft, code = 0x1a */
     public static final Multihash KECCAK_224 = Multihash.of("keccak-224", 0x1a, Multicodec.Status.Draft);
 
@@ -1089,7 +1089,7 @@ public class MultihashCodec {
     /** Multihash: x11, status = draft, code = 0x1100 */
     public static final Multihash X11 = Multihash.of("x11", 0x1100, Multicodec.Status.Draft);
 
-    protected static final Map<Long,Multicodec> ALL = new TreeMap<>();
+    protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
       ALL.put(BCRYPT_PBKDF.code(), BCRYPT_PBKDF);

--- a/src/main/java/com/apicatalog/multicodec/codec/MultihashCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/MultihashCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec;
 import com.apicatalog.multihash.Multihash;
 
-/** Multicodec Registry - generated: Mon Jul 06 22:44:55 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 23:11:10 CEST 2026 */
 public class MultihashCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:55.952Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T21:11:10.613912785Z");
 
     /** Multihash: bcrypt-pbkdf, Bcrypt-PBKDF key derivation function, status = draft, code = 0xd00d */
     public static final Multihash BCRYPT_PBKDF = Multihash.of("bcrypt-pbkdf", 0xd00d, Multicodec.Status.Draft);

--- a/src/main/java/com/apicatalog/multicodec/codec/NamespaceCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/NamespaceCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 23:11:10 CEST 2026 */
 public class NamespaceCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.007Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T21:11:10.641022680Z");
 
     /** Namespace: adnl, TON ADNL address: 32-byte SHA-256(0x4813b4c6_LE || Ed25519-pubkey), status = draft, code = 0xb69910 */
     public static final Multicodec ADNL = Multicodec.of("adnl", Tag.Namespace, 0xb69910, Multicodec.Status.Draft);

--- a/src/main/java/com/apicatalog/multicodec/codec/NamespaceCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/NamespaceCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jun 01 18:59:15 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
 public class NamespaceCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-06-01T16:59:15.578Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.007Z");
 
     /** Namespace: adnl, TON ADNL address: 32-byte SHA-256(0x4813b4c6_LE || Ed25519-pubkey), status = draft, code = 0xb69910 */
     public static final Multicodec ADNL = Multicodec.of("adnl", Tag.Namespace, 0xb69910, Multicodec.Status.Draft);
@@ -78,7 +78,7 @@ public class NamespaceCodec {
     /** Namespace: zeronet, ZeroNet site address, status = draft, code = 0xe6 */
     public static final Multicodec ZERONET = Multicodec.of("zeronet", Tag.Namespace, 0xe6, Multicodec.Status.Draft);
 
-    protected static final Map<Long,Multicodec> ALL = new TreeMap<>();
+    protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
       ALL.put(ADNL.code(), ADNL);

--- a/src/main/java/com/apicatalog/multicodec/codec/SerializationCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/SerializationCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jun 01 18:59:15 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
 public class SerializationCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-06-01T16:59:15.582Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.017Z");
 
     /** Serialization: bencode, bencode, status = draft, code = 0x63 */
     public static final Multicodec BENCODE = Multicodec.of("bencode", Tag.Serialization, 0x63, Multicodec.Status.Draft);
@@ -51,7 +51,7 @@ public class SerializationCodec {
     /** Serialization: x509-certificate, DER-encoded X.509 (PKIX) certificate per RFC 5280; single certificate only (no chain); raw DER bytes (not PEM), status = draft, code = 0x210 */
     public static final Multicodec X509_CERTIFICATE = Multicodec.of("x509-certificate", Tag.Serialization, 0x210, Multicodec.Status.Draft);
 
-    protected static final Map<Long,Multicodec> ALL = new TreeMap<>();
+    protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
       ALL.put(BENCODE.code(), BENCODE);

--- a/src/main/java/com/apicatalog/multicodec/codec/SerializationCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/SerializationCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 23:11:10 CEST 2026 */
 public class SerializationCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.017Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T21:11:10.645221891Z");
 
     /** Serialization: bencode, bencode, status = draft, code = 0x63 */
     public static final Multicodec BENCODE = Multicodec.of("bencode", Tag.Serialization, 0x63, Multicodec.Status.Draft);

--- a/src/main/java/com/apicatalog/multicodec/codec/TransportCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/TransportCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 23:11:10 CEST 2026 */
 public class TransportCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.021Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T21:11:10.648052673Z");
 
     /** Transport: transport-bitswap, Bitswap datatransfer, status = draft, code = 0x900 */
     public static final Multicodec TRANSPORT_BITSWAP = Multicodec.of("transport-bitswap", Tag.Transport, 0x900, Multicodec.Status.Draft);

--- a/src/main/java/com/apicatalog/multicodec/codec/TransportCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/TransportCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jun 01 18:59:15 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
 public class TransportCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-06-01T16:59:15.584Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.021Z");
 
     /** Transport: transport-bitswap, Bitswap datatransfer, status = draft, code = 0x900 */
     public static final Multicodec TRANSPORT_BITSWAP = Multicodec.of("transport-bitswap", Tag.Transport, 0x900, Multicodec.Status.Draft);
@@ -24,7 +24,7 @@ public class TransportCodec {
     /** Transport: transport-ipfs-gateway-http, HTTP IPFS Gateway trustless datatransfer, status = draft, code = 0x920 */
     public static final Multicodec TRANSPORT_IPFS_GATEWAY_HTTP = Multicodec.of("transport-ipfs-gateway-http", Tag.Transport, 0x920, Multicodec.Status.Draft);
 
-    protected static final Map<Long,Multicodec> ALL = new TreeMap<>();
+    protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
       ALL.put(TRANSPORT_BITSWAP.code(), TRANSPORT_BITSWAP);

--- a/src/main/java/com/apicatalog/multicodec/codec/VarsigCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/VarsigCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 23:11:10 CEST 2026 */
 public class VarsigCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.024Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T21:11:10.649934071Z");
 
     /** Varsig: bip340, BIP340 Signature Algorithm, status = draft, code = 0xd01206 */
     public static final Multicodec BIP340 = Multicodec.of("bip340", Tag.Varsig, 0xd01206, Multicodec.Status.Draft);

--- a/src/main/java/com/apicatalog/multicodec/codec/VarsigCodec.java
+++ b/src/main/java/com/apicatalog/multicodec/codec/VarsigCodec.java
@@ -7,10 +7,10 @@ import java.util.Map;
 import com.apicatalog.multicodec.Multicodec.Tag;
 import com.apicatalog.multicodec.Multicodec;
 
-/** Multicodec Registry - generated: Mon Jun 01 18:59:15 CEST 2026 */
+/** Multicodec Registry - generated: Mon Jul 06 22:44:56 CEST 2026 */
 public class VarsigCodec {
 
-    public static final Instant UPDATED = Instant.parse("2026-06-01T16:59:15.586Z");
+    public static final Instant UPDATED = Instant.parse("2026-07-06T20:44:56.024Z");
 
     /** Varsig: bip340, BIP340 Signature Algorithm, status = draft, code = 0xd01206 */
     public static final Multicodec BIP340 = Multicodec.of("bip340", Tag.Varsig, 0xd01206, Multicodec.Status.Draft);
@@ -45,7 +45,7 @@ public class VarsigCodec {
     /** Varsig: rs256, RS256 Signature Algorithm, status = draft, code = 0xd01205 */
     public static final Multicodec RS256 = Multicodec.of("rs256", Tag.Varsig, 0xd01205, Multicodec.Status.Draft);
 
-    protected static final Map<Long,Multicodec> ALL = new TreeMap<>();
+    protected static final Map<Integer,Multicodec> ALL = new TreeMap<>();
 
     static {
       ALL.put(BIP340.code(), BIP340);

--- a/src/main/java/com/apicatalog/multihash/Multihash.java
+++ b/src/main/java/com/apicatalog/multihash/Multihash.java
@@ -32,7 +32,7 @@ public class Multihash extends Multicodec {
      * @param uvarint the varint-encoded code
      * @param status  the registration status
      */
-    protected Multihash(String name, long code, byte[] uvarint, Status status) {
+    protected Multihash(String name, int code, byte[] uvarint, Status status) {
         super(name, Tag.Multihash, code, uvarint, status);
     }
 
@@ -43,7 +43,7 @@ public class Multihash extends Multicodec {
      * @param code the multicodec code
      * @return a new {@code Multihash} instance
      */
-    public static Multihash of(String name, long code) {
+    public static Multihash of(String name, int code) {
         return of(name, code, null);
     }
 
@@ -55,7 +55,7 @@ public class Multihash extends Multicodec {
      * @param status the registration status
      * @return a new {@code Multihash} instance
      */
-    public static Multihash of(String name, long code, Status status) {
+    public static Multihash of(String name, int code, Status status) {
         return new Multihash(name, code, UVarInt.encode(code), status);
     }
 
@@ -212,15 +212,17 @@ public class Multihash extends Multicodec {
 
         if (length > (encoded.length - index)) {
             throw new IllegalArgumentException(
-                    "The requested decode length (" + length + ") is greater than the available bytes (" + (encoded.length - index) + ").");
+                    "The requested decode length (" + length + ") is greater than the available bytes ("
+                            + (encoded.length - index) + ").");
         }
-        
+
         long digestLength = digestLength(encoded, index, length);
         int varintDigestLength = UVarInt.byteLength(digestLength);
 
         if (digestLength != (length - codeVarint.length - varintDigestLength)) {
             throw new IllegalArgumentException(
-                    "Digest size mismatch: declared size is " + digestLength + " bytes, but the actual digest size is " +
+                    "Digest size mismatch: declared size is " + digestLength + " bytes, but the actual digest size is "
+                            +
                             (length - codeVarint.length - varintDigestLength) + " bytes.");
         }
 
@@ -248,7 +250,7 @@ public class Multihash extends Multicodec {
      *                                  the bytes at offset {@code 0} do not start
      *                                  with this multihash's code
      */
-    public long digestLength(byte[] encoded) {
+    public int digestLength(byte[] encoded) {
         return digestLength(encoded, 0, encoded.length);
     }
 
@@ -275,11 +277,11 @@ public class Multihash extends Multicodec {
      * @throws IndexOutOfBoundsException if {@code index} is negative or exceeds the
      *                                   available range
      */
-    public long digestLength(byte[] encoded, int index) {
+    public int digestLength(byte[] encoded, int index) {
         return digestLength(encoded, index, encoded.length - index);
     }
 
-    protected long digestLength(byte[] encoded, int index, int length) {
+    protected int digestLength(byte[] encoded, int index, int length) {
         Objects.requireNonNull(encoded);
 
         if (length < (codeVarint.length + 2)) {
@@ -293,11 +295,24 @@ public class Multihash extends Multicodec {
                     "The provided value is not encoded with this multihash: " + toString() + ".");
         }
 
-        return UVarInt.decode(encoded, index + codeVarint.length);
+        long code = UVarInt.decode(encoded, index + codeVarint.length);
+
+        if (code < Integer.MIN_VALUE || code > Integer.MAX_VALUE) {
+
+            StringBuilder hex = new StringBuilder();
+            for (byte b : encoded) {
+                hex.append(String.format("%02x", b));
+            }
+
+            throw new IllegalArgumentException(
+                    "The code is out of range, code=" + Long.toUnsignedString(code) + ", varint=" + hex.toString());
+        }
+
+        return (int) code;
     }
 
     @Override
     public String toString() {
-        return "Multihash [name=" + name + ", tag=" + tag + ", code=" + code + "]";
+        return "Multihash [name=" + name + ", tag=" + tag + ", code=" + Integer.toUnsignedString(code) + "]";
     }
 }

--- a/src/test/java/com/apicatalog/multicodec/MulticodecTest.java
+++ b/src/test/java/com/apicatalog/multicodec/MulticodecTest.java
@@ -13,44 +13,44 @@ class MulticodecTest {
 
     @Test
     void testIsEncoded() {
-        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123l);
+        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123);
         assertTrue(codec.isEncoded(UVarInt.encode(123l)));
         assertFalse(codec.isEncoded(UVarInt.encode(124l)));
     }
 
     @Test
     void testEncode() {
-        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123l);
+        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123);
         assertArrayEquals(new byte[] { 0x7b, 0x48, 0x65, 0x6C, 0x6C, 0x6F }, codec.encode("Hello".getBytes()));
     }
 
     @Test
     void testEncodeFromIndex() {
-        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123l);
+        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123);
         assertArrayEquals(new byte[] { 0x7b, 0x48, 0x65, 0x6C, 0x6C, 0x6F }, codec.encode(new byte[] {'0', 'H', 'e',  'l', 'l', 'o'}, 1));
     }
 
     @Test
     void testEncodeRange() {
-        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123l);
+        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123);
         assertArrayEquals(new byte[] { 0x7b, 0x48, 0x65, 0x6C, 0x6C, 0x6F }, codec.encode(new byte[] {'A', 'B', 'H', 'e',  'l', 'l', 'o', 'C'}, 2, 5));
     }
 
     @Test
     void testDecode() {
-        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123l);
+        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123);
         assertArrayEquals("Hello".getBytes(), codec.decode(new byte[] { 0x7b, 0x48, 0x65, 0x6C, 0x6C, 0x6F }));
     }
 
     @Test
     void testDecodeFromIndex() {
-        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123l);
+        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123);
         assertArrayEquals("Hello".getBytes(), codec.decode(new byte[] { 0x0, 0x7b, 0x48, 0x65, 0x6C, 0x6C, 0x6F }, 1));
     }
 
     @Test
     void testDecodeFromRange() {
-        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123l);
+        final Multicodec codec = Multicodec.of("test-hash", Tag.Hash, 123);
         assertArrayEquals("Hello".getBytes(), codec.decode(new byte[] { 0xa, 0xb, 0x7b, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x1, 0x2, 0x3 }, 2, 6));
     }
 }

--- a/src/test/java/com/apicatalog/multicodec/codec/MulticodecDecoderTest.java
+++ b/src/test/java/com/apicatalog/multicodec/codec/MulticodecDecoderTest.java
@@ -12,7 +12,7 @@ class MulticodecDecoderTest {
 
     @Test
     void testGetInstance() {
-        final MulticodecDecoder decoder = MulticodecDecoder.getInstance();
+        final MulticodecDecoder decoder = MulticodecDecoder.newInstance();
         assertNotNull(decoder);
         assertTrue(KeyCodec.ALL.values().stream()
                 .allMatch(codec -> decoder.getCodec(codec.varint()).isPresent()));
@@ -28,7 +28,7 @@ class MulticodecDecoderTest {
 
     @Test
     void testGetInstanceKeyTag() {
-        final MulticodecDecoder decoder = MulticodecDecoder.getInstance(Tag.Key);
+        final MulticodecDecoder decoder = MulticodecDecoder.newInstance(Tag.Key);
         assertNotNull(decoder);
         assertTrue(KeyCodec.ALL.values().stream()
                 .allMatch(codec -> decoder.getCodec(codec.varint()).isPresent()));
@@ -38,7 +38,7 @@ class MulticodecDecoderTest {
 
     @Test
     void testGetInstanceHashKeyTag() {
-        final MulticodecDecoder decoder = MulticodecDecoder.getInstance(Tag.Key, Tag.Hash);
+        final MulticodecDecoder decoder = MulticodecDecoder.newInstance(Tag.Key, Tag.Hash);
         assertNotNull(decoder);
         assertTrue(KeyCodec.ALL.values().stream()
                 .allMatch(codec -> decoder.getCodec(codec.varint()).isPresent()));

--- a/src/test/java/com/apicatalog/multihash/MultihashTest.java
+++ b/src/test/java/com/apicatalog/multihash/MultihashTest.java
@@ -18,7 +18,7 @@ import com.apicatalog.uvarint.UVarInt;
 
 class MultihashTest {
 
-    static final MulticodecDecoder DECODER = MulticodecDecoder.getInstance(Tag.Multihash);
+    static final MulticodecDecoder DECODER = MulticodecDecoder.newInstance(Tag.Multihash);
 
     @ParameterizedTest(name = "{index}")
     @MethodSource("testData")


### PR DESCRIPTION

- Changed multicodec code from `long` to `int`, all codes fits.
- Replaced the `getInstance` factory method with the semantically correct `newInstance`.
- Synced with the latest registry state.